### PR TITLE
Reduces mul execution cost

### DIFF
--- a/contracts/libraries/math/SafeMath.sol
+++ b/contracts/libraries/math/SafeMath.sol
@@ -75,15 +75,8 @@ library SafeMath {
      * - Multiplication cannot overflow.
      */
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
-        // benefit is lost if 'b' is also tested.
-        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
-        if (a == 0) {
-            return 0;
-        }
-
         uint256 c = a * b;
-        require(c / a == b, "SafeMath: multiplication overflow");
+        require(a == 0 || c / a == b, "SafeMath: multiplication overflow");
 
         return c;
     }


### PR DESCRIPTION
This is a minor PR that reduces mul execution cost from 21769 down to 21748 when a != 0.

This [PR recommends ](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522#issuecomment-344159199) to add the `a == 0` test on top of the function but it turns out that with Solidity ^0.6.12 this isn't true.

Code use for testing:

```
// SPDX-License-Identifier: MIT
// OpenZeppelin Contracts (last updated v4.6.0) (utils/math/SafeMath.sol)

pragma solidity ^0.6.12;

contract SafeMath {
    function mul(uint256 a, uint256 b) public pure returns (uint256) {
        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
        // benefit is lost if 'b' is also tested.
        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
        if (a == 0) {
            return 0;
        }

        uint256 c = a * b;
        require(c / a == b, "SafeMath: multiplication overflow");

        return c;
    }

    function mul2(uint256 a, uint256 b) public pure returns (uint256) {
        uint256 c = a * b;
        require(a == 0 || c / a == b, "SafeMath: multiplication overflow");

        return c;
    }
}
```