### PR TITLE
Added incentive vesting contracts and RewardRouterV3

### DIFF
--- a/contracts/access/Guardable.sol
+++ b/contracts/access/Guardable.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+import "./Governable.sol";
+
+contract Guardable is Governable {
+    address public capsAdmin;
+    address public guardian;
+
+    modifier onlyCapsAdmin() {
+        require(msg.sender == capsAdmin, "Guardable: forbidden");
+        _;
+    }
+
+    modifier onlyGuardian() {
+        require(msg.sender == guardian, "Guardable: forbidden");
+        _;
+    }
+
+    function setCapsAdmin(address _capsAdmin) external onlyGov {
+        capsAdmin = _capsAdmin;
+    }
+
+    function setGuardian(address _guardian) external onlyGov {
+        guardian = _guardian;
+    }
+}

--- a/contracts/peripherals/RatioVesterReader.sol
+++ b/contracts/peripherals/RatioVesterReader.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../staking/RatioVester.sol";
+import "../staking/EsGmxIssuer.sol";
+
+contract RatioVesterReader {
+    uint256 public constant VESTING_INFO_PROPS_LENGTH = 12;
+
+    function getVestingInfo(address[] memory _vesters, address _account) public view returns (uint256[] memory) {
+        uint256[] memory amounts = new uint256[](_vesters.length * VESTING_INFO_PROPS_LENGTH);
+        for (uint256 i = 0; i < _vesters.length; i++) {
+            RatioVester vester = RatioVester(_vesters[i]);
+            uint256 offset = i * VESTING_INFO_PROPS_LENGTH;
+            amounts[offset] = vester.balances(_account);
+            amounts[offset + 1] = vester.pairAmounts(_account);
+            amounts[offset + 2] = vester.claimable(_account);
+            amounts[offset + 3] = vester.cumulativeClaimAmounts(_account);
+            amounts[offset + 4] = vester.claimedAmounts(_account);
+            amounts[offset + 5] = vester.unpaidClaimAmounts(_account);
+            amounts[offset + 6] = vester.totalConvertedAmounts(_account);
+            amounts[offset + 7] = vester.getVestingCap(_account);
+            amounts[offset + 8] = vester.tranchesLength(_account) - vester.trancheStartIndex(_account);
+            amounts[offset + 9] = vester.vestingDuration();
+            amounts[offset + 10] = vester.deactivatedAt();
+            amounts[offset + 11] = vester.pairRatioFactor();
+        }
+        return amounts;
+    }
+
+    function getTranches(address _vester, address _account) public view returns (
+        uint256[] memory startTimes,
+        uint256[] memory totalAmounts,
+        uint256[] memory convertedAmounts
+    ) {
+        RatioVester vester = RatioVester(_vester);
+        uint256 startIndex = vester.trancheStartIndex(_account);
+        uint256 length = vester.tranchesLength(_account);
+        uint256 liveCount = length - startIndex;
+
+        startTimes = new uint256[](liveCount);
+        totalAmounts = new uint256[](liveCount);
+        convertedAmounts = new uint256[](liveCount);
+
+        for (uint256 i = 0; i < liveCount; i++) {
+            (uint256 startTime, uint256 totalAmount, uint256 convertedAmount) = vester.tranches(_account, startIndex + i);
+            startTimes[i] = startTime;
+            totalAmounts[i] = totalAmount;
+            convertedAmounts[i] = convertedAmount;
+        }
+    }
+
+    function getIssuerInfo(address _issuer, address _account) public view returns (uint256[] memory) {
+        EsGmxIssuer issuer = EsGmxIssuer(_issuer);
+        uint256[] memory amounts = new uint256[](5);
+        amounts[0] = issuer.issuedAmounts(_account);
+        amounts[1] = issuer.claimedAmounts(_account);
+        amounts[2] = issuer.claimable(_account);
+        amounts[3] = issuer.totalIssuedAmount();
+        amounts[4] = issuer.totalClaimedAmount();
+        return amounts;
+    }
+}

--- a/contracts/staking/EsGmxIssuer.sol
+++ b/contracts/staking/EsGmxIssuer.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+import "../libraries/math/SafeMath.sol";
+import "../libraries/token/IERC20.sol";
+import "../libraries/token/SafeERC20.sol";
+import "../libraries/utils/ReentrancyGuard.sol";
+
+import "./interfaces/IEsGmxIssuer.sol";
+import "../access/Guardable.sol";
+
+contract EsGmxIssuer is IEsGmxIssuer, ReentrancyGuard, Guardable {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    struct Epoch {
+        bool finalized;
+        uint256 entryCount;
+        uint256 totalAmount;
+    }
+
+    address public esGmx;
+    address public override vester;
+
+    uint256 public totalIssuedAmount;
+    uint256 public totalClaimedAmount;
+
+    bool public claimsPaused;
+
+    mapping (address => uint256) public override issuedAmounts;
+    mapping (address => uint256) public claimedAmounts;
+
+    mapping (address => bool) public isHandler;
+    mapping (address => bool) public isDistributor;
+
+    mapping (uint256 => Epoch) public epochs;
+    mapping (uint256 => mapping (uint256 => bool)) public processedBatchIndexes;
+    mapping (uint256 => mapping (bytes32 => bool)) public processedBatchHashes;
+
+    event Issue(uint256 epochId, uint256 batchIndex, address account, uint256 amount);
+    event BatchDistributed(uint256 epochId, uint256 batchIndex, uint256 entryCount, uint256 totalAmount);
+    event EpochFinalized(uint256 epochId, uint256 entryCount, uint256 totalAmount);
+    event Claim(address account, uint256 amount);
+    event IssuanceReduced(address account, uint256 amount);
+
+    constructor(address _esGmx) public {
+        esGmx = _esGmx;
+    }
+
+    function setHandler(address _handler, bool _isActive) external onlyGov {
+        isHandler[_handler] = _isActive;
+    }
+
+    function setDistributor(address _distributor, bool _isActive) external onlyCapsAdmin {
+        isDistributor[_distributor] = _isActive;
+    }
+
+    function setClaimsPaused(bool _claimsPaused) external onlyGuardian {
+        claimsPaused = _claimsPaused;
+    }
+
+    function setVester(address _vester) external onlyGov {
+        require(vester == address(0), "EsGmxIssuer: vester already set");
+        require(_vester != address(0), "EsGmxIssuer: invalid vester");
+        vester = _vester;
+    }
+
+    function withdrawToken(address _token, address _account, uint256 _amount) external onlyGov {
+        if (_token == esGmx) {
+            uint256 balance = IERC20(esGmx).balanceOf(address(this));
+            uint256 outstanding = totalIssuedAmount.sub(totalClaimedAmount);
+            require(_amount <= balance.sub(outstanding), "EsGmxIssuer: amount exceeds excess balance");
+        }
+        IERC20(_token).safeTransfer(_account, _amount);
+    }
+
+    function distributeEpoch(
+        uint256 _epochId,
+        uint256 _batchIndex,
+        address[] calldata _accounts,
+        uint256[] calldata _amounts
+    ) external nonReentrant {
+        require(isDistributor[msg.sender], "EsGmxIssuer: forbidden");
+        require(_accounts.length > 0, "EsGmxIssuer: empty batch");
+        require(_accounts.length == _amounts.length, "EsGmxIssuer: invalid input lengths");
+        require(!epochs[_epochId].finalized, "EsGmxIssuer: epoch finalized");
+        require(!processedBatchIndexes[_epochId][_batchIndex], "EsGmxIssuer: batch index already processed");
+
+        bytes32 batchHash = keccak256(abi.encode(_accounts, _amounts));
+        require(!processedBatchHashes[_epochId][batchHash], "EsGmxIssuer: batch content already processed");
+
+        processedBatchIndexes[_epochId][_batchIndex] = true;
+        processedBatchHashes[_epochId][batchHash] = true;
+
+        uint256 batchTotal = 0;
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            // ascending order closes the intra-batch duplicate-account blind spot
+            if (i > 0) {
+                require(_accounts[i] > _accounts[i - 1], "EsGmxIssuer: accounts not sorted");
+            }
+            address account = _accounts[i];
+            uint256 amount = _amounts[i];
+            require(account != address(0), "EsGmxIssuer: invalid account");
+            require(amount > 0, "EsGmxIssuer: invalid amount");
+
+            issuedAmounts[account] = issuedAmounts[account].add(amount);
+            batchTotal = batchTotal.add(amount);
+
+            emit Issue(_epochId, _batchIndex, account, amount);
+        }
+
+        totalIssuedAmount = totalIssuedAmount.add(batchTotal);
+        epochs[_epochId].entryCount = epochs[_epochId].entryCount.add(_accounts.length);
+        epochs[_epochId].totalAmount = epochs[_epochId].totalAmount.add(batchTotal);
+
+        require(
+            totalIssuedAmount.sub(totalClaimedAmount) <= IERC20(esGmx).balanceOf(address(this)),
+            "EsGmxIssuer: insufficient esGMX for issuance"
+        );
+
+        emit BatchDistributed(_epochId, _batchIndex, _accounts.length, batchTotal);
+    }
+
+    function finalizeEpoch(uint256 _epochId, uint256 _expectedEntryCount, uint256 _expectedTotal) external onlyCapsAdmin {
+        Epoch storage epoch = epochs[_epochId];
+        require(!epoch.finalized, "EsGmxIssuer: epoch finalized");
+        require(epoch.entryCount == _expectedEntryCount, "EsGmxIssuer: entry count mismatch");
+        require(epoch.totalAmount == _expectedTotal, "EsGmxIssuer: total amount mismatch");
+        epoch.finalized = true;
+        emit EpochFinalized(_epochId, epoch.entryCount, epoch.totalAmount);
+    }
+
+    function claim() external nonReentrant returns (uint256) {
+        return _claim(msg.sender);
+    }
+
+    function claimForAccount(address _account) external override nonReentrant returns (uint256) {
+        require(isHandler[msg.sender], "EsGmxIssuer: forbidden");
+        return _claim(_account);
+    }
+
+    function reduceIssuedAmount(address _account, uint256 _amount) external onlyCapsAdmin nonReentrant {
+        require(_amount <= claimable(_account), "EsGmxIssuer: amount exceeds unclaimed");
+        issuedAmounts[_account] = issuedAmounts[_account].sub(_amount);
+        totalIssuedAmount = totalIssuedAmount.sub(_amount);
+        emit IssuanceReduced(_account, _amount);
+    }
+
+    function claimable(address _account) public view override returns (uint256) {
+        return issuedAmounts[_account].sub(claimedAmounts[_account]);
+    }
+
+    function _claim(address _account) private returns (uint256) {
+        require(!claimsPaused, "EsGmxIssuer: claims paused");
+        uint256 amount = claimable(_account);
+        if (amount == 0) { return 0; }
+
+        claimedAmounts[_account] = claimedAmounts[_account].add(amount);
+        totalClaimedAmount = totalClaimedAmount.add(amount);
+        IERC20(esGmx).safeTransfer(_account, amount);
+
+        emit Claim(_account, amount);
+        return amount;
+    }
+}

--- a/contracts/staking/RatioVester.sol
+++ b/contracts/staking/RatioVester.sol
@@ -1,0 +1,521 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+import "../libraries/math/SafeMath.sol";
+import "../libraries/token/IERC20.sol";
+import "../libraries/token/SafeERC20.sol";
+import "../libraries/utils/ReentrancyGuard.sol";
+
+import "./interfaces/IEsGmxIssuer.sol";
+import "./interfaces/IRatioVester.sol";
+import "../tokens/interfaces/IMintable.sol";
+import "../access/Guardable.sol";
+
+contract RatioVester is IRatioVester, IERC20, ReentrancyGuard, Guardable {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    struct Tranche {
+        uint256 startTime;
+        uint256 totalAmount;
+        uint256 convertedAmount;
+    }
+
+    uint256 public constant PAIR_RATIO_PRECISION = 10 ** 30;
+    uint256 public constant EPOCH_DURATION = 7 days;
+    // unix epoch day zero is a Thursday; the offset aligns epoch boundaries to Wednesday 00:00 UTC
+    uint256 public constant EPOCH_OFFSET = 1 days;
+    uint256 public constant MIN_DEACTIVATION_NOTICE = 7 days;
+
+    string public name;
+    string public symbol;
+    uint8 public decimals = 18;
+
+    uint256 public vestingDuration;
+
+    address public esToken;
+    address public pairToken;
+    address public claimableToken;
+    address public override issuer;
+
+    uint256 public pairRatioFactor;
+    bool public isUncapped;
+
+    bool public isIssuerBindingConfirmed;
+    bool public provisioningComplete;
+    bool public depositPaused;
+    bool public transferPaused;
+    uint256 public deactivatedAt;
+
+    uint256 public override totalSupply;
+    uint256 public pairSupply;
+    uint256 public totalConverted;
+    uint256 public totalGmxClaimed;
+
+    mapping (address => uint256) public balances;
+    mapping (address => uint256) public override pairAmounts;
+    mapping (address => uint256) public cumulativeClaimAmounts;
+    mapping (address => uint256) public claimedAmounts;
+    mapping (address => uint256) public unpaidClaimAmounts;
+    mapping (address => uint256) public totalConvertedAmounts;
+
+    mapping (address => uint256) public provisionCaps;
+    mapping (address => uint256) public transferredCaps;
+    mapping (address => uint256) public transferredCapDeductions;
+    mapping (address => uint256) public govCapDeductions;
+
+    mapping (address => Tranche[]) public tranches;
+    mapping (address => uint256) public trancheStartIndex;
+
+    mapping (address => bool) public override isHandler;
+    mapping (address => bool) public override isFrozen;
+
+    event Deposit(address account, uint256 amount, uint256 pairShortfall);
+    event Withdraw(address account, uint256 esAmount, uint256 pairAmount, uint256 unpaidCarried);
+    event Claim(address receiver, uint256 amount);
+    event Convert(address account, uint256 amount);
+    event PairTransfer(address indexed from, address indexed to, uint256 value);
+    event ProvisionCapSet(address account, uint256 cap);
+    event CapDeductionIncreased(address account, uint256 amount);
+    event CapDeductionDecreased(address account, uint256 amount);
+    event AccountFrozenSet(address account, bool isFrozen);
+    event DeactivatedAtSet(uint256 deactivatedAt);
+    event VestingStateTransferred(address sender, address receiver, uint256 cap, uint256 usage, uint256 unpaid);
+
+    constructor (
+        string memory _name,
+        string memory _symbol,
+        uint256 _vestingDuration,
+        address _esToken,
+        address _pairToken,
+        address _claimableToken,
+        address _issuer,
+        uint256 _pairRatioFactor,
+        bool _isUncapped
+    ) public {
+        name = _name;
+        symbol = _symbol;
+
+        vestingDuration = _vestingDuration;
+
+        esToken = _esToken;
+        pairToken = _pairToken;
+        claimableToken = _claimableToken;
+        issuer = _issuer;
+
+        pairRatioFactor = _pairRatioFactor;
+        isUncapped = _isUncapped;
+    }
+
+    function setHandler(address _handler, bool _isActive) external onlyGov {
+        isHandler[_handler] = _isActive;
+    }
+
+    function setDepositPaused(bool _depositPaused) external onlyGuardian {
+        depositPaused = _depositPaused;
+    }
+
+    function setTransferPaused(bool _transferPaused) external onlyGuardian {
+        transferPaused = _transferPaused;
+    }
+
+    function setAccountFrozen(address _account, bool _isFrozen) external onlyGuardian {
+        isFrozen[_account] = _isFrozen;
+        emit AccountFrozenSet(_account, _isFrozen);
+    }
+
+    function increaseCapDeduction(address _account, uint256 _amount) external onlyGuardian {
+        govCapDeductions[_account] = govCapDeductions[_account].add(_amount);
+        emit CapDeductionIncreased(_account, _amount);
+    }
+
+    function decreaseCapDeduction(address _account, uint256 _amount) external onlyGov {
+        govCapDeductions[_account] = govCapDeductions[_account].sub(_amount);
+        emit CapDeductionDecreased(_account, _amount);
+    }
+
+    function setDeactivatedAt(uint256 _deactivatedAt) external onlyGov {
+        require(deactivatedAt == 0 || block.timestamp < deactivatedAt, "RatioVester: already deactivated");
+        if (deactivatedAt == 0) {
+            require(_deactivatedAt >= block.timestamp.add(MIN_DEACTIVATION_NOTICE), "RatioVester: notice period too short");
+        } else {
+            require(_deactivatedAt > deactivatedAt, "RatioVester: can only push out");
+        }
+        deactivatedAt = _deactivatedAt;
+        emit DeactivatedAtSet(_deactivatedAt);
+    }
+
+    function confirmIssuerBinding() external {
+        require(issuer != address(0), "RatioVester: no issuer");
+        require(IEsGmxIssuer(issuer).vester() == address(this), "RatioVester: issuer not bound");
+        isIssuerBindingConfirmed = true;
+    }
+
+    function setProvisionCaps(address[] calldata _accounts, uint256[] calldata _caps) external onlyCapsAdmin {
+        require(!provisioningComplete, "RatioVester: provisioning complete");
+        require(_accounts.length == _caps.length, "RatioVester: invalid input lengths");
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            provisionCaps[_accounts[i]] = _caps[i];
+            emit ProvisionCapSet(_accounts[i], _caps[i]);
+        }
+    }
+
+    function setProvisioningComplete() external onlyCapsAdmin {
+        provisioningComplete = true;
+    }
+
+    function withdrawToken(address _token, address _receiver, uint256 _amount) external onlyGov {
+        uint256 balance = IERC20(_token).balanceOf(address(this));
+        if (_token == pairToken) {
+            require(_amount <= balance.sub(pairSupply), "RatioVester: amount exceeds excess balance");
+        } else if (_token == esToken) {
+            require(_amount <= balance.sub(totalSupply), "RatioVester: amount exceeds excess balance");
+        } else if (_token == claimableToken) {
+            uint256 obligations = totalSupply.add(totalConverted.sub(totalGmxClaimed));
+            require(_amount <= balance.sub(obligations), "RatioVester: amount exceeds excess balance");
+        }
+        IERC20(_token).safeTransfer(_receiver, _amount);
+    }
+
+    function deposit(uint256 _amount) external nonReentrant {
+        _deposit(msg.sender, _amount);
+    }
+
+    function depositForAccount(address _account, uint256 _amount) external override nonReentrant {
+        _validateHandler();
+        _deposit(_account, _amount);
+    }
+
+    function withdraw() external nonReentrant {
+        _withdraw(msg.sender);
+    }
+
+    function withdrawForAccount(address _account) external override nonReentrant {
+        _validateHandler();
+        _withdraw(_account);
+    }
+
+    function claim() external nonReentrant returns (uint256) {
+        return _claim(msg.sender);
+    }
+
+    function claimForAccount(address _account) external override nonReentrant returns (uint256) {
+        _validateHandler();
+        return _claim(_account);
+    }
+
+    function settleTranches(address _account, uint256 _maxTranches) external nonReentrant {
+        _settle(_account, _maxTranches);
+    }
+
+    function transferVestingState(address _sender, address _receiver) external override nonReentrant {
+        _validateHandler();
+        require(provisioningComplete, "RatioVester: provisioning not complete");
+        require(!transferPaused, "RatioVester: transfers paused");
+        require(_sender != _receiver, "RatioVester: self transfer");
+        require(!isFrozen[_sender] && !isFrozen[_receiver], "RatioVester: account frozen");
+
+        _settle(_sender, uint256(-1));
+        require(!hasOpenSession(_sender), "RatioVester: sender has open session");
+        require(isFreshForTransfer(_receiver), "RatioVester: receiver not fresh");
+
+        uint256 cap = getVestingCap(_sender);
+        uint256 usageMoved = 0;
+        if (cap > 0 && !(issuer == address(0) && isUncapped)) {
+            transferredCaps[_receiver] = transferredCaps[_receiver].add(cap);
+            transferredCapDeductions[_sender] = transferredCapDeductions[_sender].add(cap);
+            usageMoved = totalConvertedAmounts[_sender] < cap ? totalConvertedAmounts[_sender] : cap;
+            totalConvertedAmounts[_sender] = totalConvertedAmounts[_sender].sub(usageMoved);
+            totalConvertedAmounts[_receiver] = totalConvertedAmounts[_receiver].add(usageMoved);
+        }
+
+        uint256 unpaid = unpaidClaimAmounts[_sender];
+        if (unpaid > 0) {
+            unpaidClaimAmounts[_sender] = 0;
+            unpaidClaimAmounts[_receiver] = unpaidClaimAmounts[_receiver].add(unpaid);
+        }
+
+        emit VestingStateTransferred(_sender, _receiver, cap, usageMoved, unpaid);
+    }
+
+    function getVestingCap(address _account) public view override returns (uint256) {
+        if (issuer == address(0) && isUncapped) { return uint256(-1); }
+
+        uint256 cap = provisionCaps[_account].add(transferredCaps[_account]);
+        if (issuer != address(0)) {
+            cap = cap.add(IEsGmxIssuer(issuer).issuedAmounts(_account));
+        }
+
+        // subtract each deduction with saturation so an oversized deduction can never brick settlement or withdrawal
+        uint256 transferredDeduction = transferredCapDeductions[_account];
+        cap = cap > transferredDeduction ? cap - transferredDeduction : 0;
+        uint256 govDeduction = govCapDeductions[_account];
+        return cap > govDeduction ? cap - govDeduction : 0;
+    }
+
+    function getTotalVested(address _account) public view returns (uint256) {
+        return balances[_account].add(totalConvertedAmounts[_account]);
+    }
+
+    function getPairRequirement(uint256 _balance) public view returns (uint256) {
+        return _balance.mul(pairRatioFactor).add(PAIR_RATIO_PRECISION.sub(1)).div(PAIR_RATIO_PRECISION);
+    }
+
+    function currentEpoch() public view returns (uint256) {
+        return block.timestamp.add(EPOCH_OFFSET).div(EPOCH_DURATION);
+    }
+
+    function isDeactivated() public view returns (bool) {
+        return deactivatedAt != 0 && block.timestamp >= deactivatedAt;
+    }
+
+    function tranchesLength(address _account) external view returns (uint256) {
+        return tranches[_account].length;
+    }
+
+    function hasOpenSession(address _account) public view override returns (bool) {
+        return balances[_account] > 0 || pairAmounts[_account] > 0 || cumulativeClaimAmounts[_account] > 0;
+    }
+
+    function isFreshForTransfer(address _account) public view override returns (bool) {
+        return balances[_account] == 0
+            && pairAmounts[_account] == 0
+            && cumulativeClaimAmounts[_account] == 0
+            && claimedAmounts[_account] == 0
+            && unpaidClaimAmounts[_account] == 0
+            && totalConvertedAmounts[_account] == 0
+            && transferredCaps[_account] == 0
+            && transferredCapDeductions[_account] == 0
+            && govCapDeductions[_account] == 0
+            && tranches[_account].length == trancheStartIndex[_account];
+    }
+
+    function claimable(address _account) public view override returns (uint256) {
+        uint256 amount = cumulativeClaimAmounts[_account].sub(claimedAmounts[_account]).add(unpaidClaimAmounts[_account]);
+        return amount.add(_pendingConversion(_account));
+    }
+
+    function balanceOf(address _account) external view override returns (uint256) {
+        return balances[_account];
+    }
+
+    // the vester receipt is non-transferable, matching the legacy Vester
+    function transfer(address, uint256) external override returns (bool) {
+        revert("RatioVester: non-transferrable");
+    }
+
+    function allowance(address, address) external view override returns (uint256) {
+        return 0;
+    }
+
+    function approve(address, uint256) external override returns (bool) {
+        revert("RatioVester: non-transferrable");
+    }
+
+    function transferFrom(address, address, uint256) external override returns (bool) {
+        revert("RatioVester: non-transferrable");
+    }
+
+    function _deposit(address _account, uint256 _amount) private {
+        require(!depositPaused, "RatioVester: deposits paused");
+        require(!isDeactivated(), "RatioVester: deactivated");
+        require(_amount > 0, "RatioVester: invalid amount");
+        if (issuer != address(0)) {
+            require(isIssuerBindingConfirmed, "RatioVester: issuer binding not confirmed");
+        }
+
+        _settle(_account, uint256(-1));
+
+        uint256 cap = getVestingCap(_account);
+        if (cap != uint256(-1)) {
+            require(getTotalVested(_account).add(_amount) <= cap, "RatioVester: cap exceeded");
+        }
+
+        uint256 obligations = totalSupply.add(_amount).add(totalConverted.sub(totalGmxClaimed));
+        require(obligations <= IERC20(claimableToken).balanceOf(address(this)), "RatioVester: insufficient backing");
+
+        IERC20(esToken).safeTransferFrom(_account, address(this), _amount);
+
+        Tranche[] storage list = tranches[_account];
+        uint256 epoch = currentEpoch();
+        bool merged = false;
+        if (list.length > trancheStartIndex[_account]) {
+            Tranche storage last = list[list.length - 1];
+            if (last.startTime.add(EPOCH_OFFSET).div(EPOCH_DURATION) == epoch) {
+                last.totalAmount = last.totalAmount.add(_amount);
+                merged = true;
+            }
+        }
+        if (!merged) {
+            list.push(Tranche({
+                startTime: block.timestamp,
+                totalAmount: _amount,
+                convertedAmount: 0
+            }));
+        }
+
+        balances[_account] = balances[_account].add(_amount);
+        totalSupply = totalSupply.add(_amount);
+        emit Transfer(address(0), _account, _amount);
+
+        uint256 requirement = getPairRequirement(balances[_account]);
+        uint256 shortfall = 0;
+        if (requirement > pairAmounts[_account]) {
+            shortfall = requirement.sub(pairAmounts[_account]);
+            IERC20(pairToken).safeTransferFrom(_account, address(this), shortfall);
+            pairAmounts[_account] = pairAmounts[_account].add(shortfall);
+            pairSupply = pairSupply.add(shortfall);
+            emit PairTransfer(_account, address(this), shortfall);
+        }
+
+        emit Deposit(_account, _amount, shortfall);
+    }
+
+    function _withdraw(address _account) private {
+        _settle(_account, uint256(-1));
+
+        uint256 balance = balances[_account];
+        uint256 pairAmount = pairAmounts[_account];
+        require(balance > 0 || pairAmount > 0 || cumulativeClaimAmounts[_account] > 0, "RatioVester: nothing to withdraw");
+
+        uint256 unpaid = cumulativeClaimAmounts[_account].sub(claimedAmounts[_account]);
+        if (unpaid > 0) {
+            unpaidClaimAmounts[_account] = unpaidClaimAmounts[_account].add(unpaid);
+        }
+        delete cumulativeClaimAmounts[_account];
+        delete claimedAmounts[_account];
+
+        trancheStartIndex[_account] = tranches[_account].length;
+
+        if (balance > 0) {
+            balances[_account] = 0;
+            totalSupply = totalSupply.sub(balance);
+            IERC20(esToken).safeTransfer(_account, balance);
+            emit Transfer(_account, address(0), balance);
+        }
+
+        if (pairAmount > 0) {
+            pairAmounts[_account] = 0;
+            pairSupply = pairSupply.sub(pairAmount);
+            IERC20(pairToken).safeTransfer(_account, pairAmount);
+            emit PairTransfer(address(this), _account, pairAmount);
+        }
+
+        emit Withdraw(_account, balance, pairAmount, unpaid);
+    }
+
+    function _claim(address _account) private returns (uint256) {
+        require(!isFrozen[_account], "RatioVester: account frozen");
+        _settle(_account, uint256(-1));
+
+        uint256 amount = cumulativeClaimAmounts[_account].sub(claimedAmounts[_account]).add(unpaidClaimAmounts[_account]);
+        if (amount == 0) { return 0; }
+
+        claimedAmounts[_account] = cumulativeClaimAmounts[_account];
+        unpaidClaimAmounts[_account] = 0;
+        totalGmxClaimed = totalGmxClaimed.add(amount);
+
+        IERC20(claimableToken).safeTransfer(_account, amount);
+        emit Claim(_account, amount);
+        return amount;
+    }
+
+    function _settle(address _account, uint256 _maxTranches) private {
+        if (isFrozen[_account]) { return; }
+
+        Tranche[] storage list = tranches[_account];
+        uint256 start = trancheStartIndex[_account];
+        uint256 endTime = block.timestamp;
+        if (deactivatedAt != 0 && endTime > deactivatedAt) { endTime = deactivatedAt; }
+
+        uint256 headroom = _capHeadroom(_account);
+        uint256 totalDelta = 0;
+        uint256 processed = 0;
+
+        for (uint256 i = start; i < list.length; i++) {
+            if (processed >= _maxTranches) { break; }
+            processed = processed.add(1);
+
+            Tranche storage tranche = list[i];
+            uint256 elapsed = endTime > tranche.startTime ? endTime.sub(tranche.startTime) : 0;
+            if (elapsed > vestingDuration) { elapsed = vestingDuration; }
+
+            uint256 target = tranche.totalAmount.mul(elapsed).div(vestingDuration);
+            if (target > tranche.convertedAmount) {
+                uint256 delta = target.sub(tranche.convertedAmount);
+                if (headroom != uint256(-1) && delta > headroom) { delta = headroom; }
+                if (delta > 0) {
+                    tranche.convertedAmount = tranche.convertedAmount.add(delta);
+                    totalDelta = totalDelta.add(delta);
+                    if (headroom != uint256(-1)) { headroom = headroom.sub(delta); }
+                }
+            }
+
+            if (tranche.convertedAmount == tranche.totalAmount && i == start) {
+                start = start.add(1);
+            }
+
+            if (headroom == 0) { break; }
+        }
+
+        if (start != trancheStartIndex[_account]) {
+            trancheStartIndex[_account] = start;
+        }
+
+        if (totalDelta > 0) {
+            balances[_account] = balances[_account].sub(totalDelta);
+            totalSupply = totalSupply.sub(totalDelta);
+            cumulativeClaimAmounts[_account] = cumulativeClaimAmounts[_account].add(totalDelta);
+            totalConvertedAmounts[_account] = totalConvertedAmounts[_account].add(totalDelta);
+            totalConverted = totalConverted.add(totalDelta);
+
+            IMintable(esToken).burn(address(this), totalDelta);
+            emit Transfer(_account, address(0), totalDelta);
+            emit Convert(_account, totalDelta);
+        }
+    }
+
+    function _pendingConversion(address _account) private view returns (uint256) {
+        if (isFrozen[_account]) { return 0; }
+
+        Tranche[] storage list = tranches[_account];
+        uint256 endTime = block.timestamp;
+        if (deactivatedAt != 0 && endTime > deactivatedAt) { endTime = deactivatedAt; }
+
+        uint256 headroom = _capHeadroom(_account);
+        uint256 totalDelta = 0;
+
+        for (uint256 i = trancheStartIndex[_account]; i < list.length; i++) {
+            Tranche storage tranche = list[i];
+            uint256 elapsed = endTime > tranche.startTime ? endTime.sub(tranche.startTime) : 0;
+            if (elapsed > vestingDuration) { elapsed = vestingDuration; }
+
+            uint256 target = tranche.totalAmount.mul(elapsed).div(vestingDuration);
+            if (target > tranche.convertedAmount) {
+                uint256 delta = target.sub(tranche.convertedAmount);
+                if (headroom != uint256(-1)) {
+                    if (delta > headroom) { delta = headroom; }
+                    headroom = headroom.sub(delta);
+                }
+                totalDelta = totalDelta.add(delta);
+            }
+
+            if (headroom == 0) { break; }
+        }
+
+        return totalDelta;
+    }
+
+    function _capHeadroom(address _account) private view returns (uint256) {
+        uint256 cap = getVestingCap(_account);
+        if (cap == uint256(-1)) { return uint256(-1); }
+        uint256 used = totalConvertedAmounts[_account];
+        if (cap <= used) { return 0; }
+        return cap.sub(used);
+    }
+
+    function _validateHandler() private view {
+        require(isHandler[msg.sender], "RatioVester: forbidden");
+    }
+}

--- a/contracts/staking/RewardRouterV3.sol
+++ b/contracts/staking/RewardRouterV3.sol
@@ -1,0 +1,725 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "../libraries/math/SafeMath.sol";
+import "../libraries/token/IERC20.sol";
+import "../libraries/token/SafeERC20.sol";
+import "../libraries/utils/ReentrancyGuard.sol";
+import "../libraries/utils/Address.sol";
+
+import "./interfaces/IExternalHandler.sol";
+import "./interfaces/IRewardTracker.sol";
+import "./interfaces/IRewardRouterV2.sol";
+import "./interfaces/IVester.sol";
+import "./interfaces/IRatioVester.sol";
+import "./interfaces/IEsGmxIssuer.sol";
+import "../tokens/interfaces/IMintable.sol";
+import "../tokens/interfaces/IWETH.sol";
+import "../access/Governable.sol";
+
+contract RewardRouterV3 is IRewardRouterV2, ReentrancyGuard, Governable {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+    using Address for address payable;
+
+    enum VotingPowerType {
+        None,
+        BaseStakedAmount,
+        BaseAndBonusStakedAmount
+    }
+
+    struct InitializeParams {
+        address weth;
+        address gmx;
+        address esGmx;
+        address bnGmx;
+        address glp;
+        address stakedGmxTracker;
+        address bonusGmxTracker;
+        address extendedGmxTracker;
+        address feeGmxTracker;
+        address feeGlpTracker;
+        address stakedGlpTracker;
+        address glpManager;
+        address gmxVester;
+        address glpVester;
+        address externalHandler;
+        address govToken;
+        address esGmxIssuer;
+    }
+
+    uint256 public constant BASIS_POINTS_DIVISOR = 10000;
+
+    bool public isInitialized;
+
+    address public weth;
+
+    address public gmx;
+    address public esGmx;
+    address public bnGmx;
+
+    address public override glp; // GMX Liquidity Provider token
+
+    address public stakedGmxTracker;
+    address public bonusGmxTracker;
+    address public extendedGmxTracker;
+    address public feeGmxTracker;
+
+    address public override stakedGlpTracker;
+    address public override feeGlpTracker;
+
+    address public glpManager;
+
+    address public gmxVester;
+    address public glpVester;
+
+    address public externalHandler;
+
+    address public esGmxIssuer;
+    address[] public designatedVesters;
+    mapping (address => bool) public isDesignatedVester;
+
+    uint256 public maxBoostBasisPoints;
+    bool public inStrictTransferMode;
+
+    address public govToken;
+    VotingPowerType public votingPowerType;
+
+    bool public inRestakingMode;
+
+    mapping (address => address) public pendingReceivers;
+
+    event StakeGmx(address account, address token, uint256 amount);
+    event UnstakeGmx(address account, address token, uint256 amount);
+
+    receive() external payable {
+        require(msg.sender == weth, "Router: invalid sender");
+    }
+
+    function initialize(InitializeParams memory _initializeParams) external onlyGov {
+        require(!isInitialized, "already initialized");
+        isInitialized = true;
+
+        weth = _initializeParams.weth;
+
+        gmx = _initializeParams.gmx;
+        esGmx = _initializeParams.esGmx;
+        bnGmx = _initializeParams.bnGmx;
+
+        glp = _initializeParams.glp;
+
+        stakedGmxTracker = _initializeParams.stakedGmxTracker;
+        bonusGmxTracker = _initializeParams.bonusGmxTracker;
+        extendedGmxTracker = _initializeParams.extendedGmxTracker;
+        feeGmxTracker = _initializeParams.feeGmxTracker;
+
+        feeGlpTracker = _initializeParams.feeGlpTracker;
+        stakedGlpTracker = _initializeParams.stakedGlpTracker;
+
+        glpManager = _initializeParams.glpManager;
+
+        gmxVester = _initializeParams.gmxVester;
+        glpVester = _initializeParams.glpVester;
+
+        externalHandler = _initializeParams.externalHandler;
+
+        govToken = _initializeParams.govToken;
+
+        esGmxIssuer = _initializeParams.esGmxIssuer;
+    }
+
+    function setGovToken(address _govToken) external onlyGov {
+        govToken = _govToken;
+    }
+
+    function setInStrictTransferMode(bool _inStrictTransferMode) external onlyGov {
+        inStrictTransferMode = _inStrictTransferMode;
+    }
+
+    function setMaxBoostBasisPoints(uint256 _maxBoostBasisPoints) external onlyGov {
+        maxBoostBasisPoints = _maxBoostBasisPoints;
+    }
+
+    function setVotingPowerType(VotingPowerType _votingPowerType) external onlyGov {
+        votingPowerType = _votingPowerType;
+    }
+
+    function setInRestakingMode(bool _inRestakingMode) external onlyGov {
+        inRestakingMode = _inRestakingMode;
+    }
+
+    function setEsGmxIssuer(address _esGmxIssuer) external onlyGov {
+        esGmxIssuer = _esGmxIssuer;
+    }
+
+    function addDesignatedVester(address _vester) external onlyGov {
+        require(!isDesignatedVester[_vester], "already designated");
+        isDesignatedVester[_vester] = true;
+        designatedVesters.push(_vester);
+    }
+
+    function removeDesignatedVester(address _vester) external onlyGov {
+        require(isDesignatedVester[_vester], "not designated");
+        isDesignatedVester[_vester] = false;
+        for (uint256 i = 0; i < designatedVesters.length; i++) {
+            if (designatedVesters[i] == _vester) {
+                designatedVesters[i] = designatedVesters[designatedVesters.length - 1];
+                designatedVesters.pop();
+                break;
+            }
+        }
+    }
+
+    function designatedVestersLength() external view returns (uint256) {
+        return designatedVesters.length;
+    }
+
+    // to help users who accidentally send their tokens to this contract
+    function withdrawToken(address _token, address _account, uint256 _amount) external onlyGov {
+        IERC20(_token).safeTransfer(_account, _amount);
+    }
+
+    function batchStakeGmxForAccounts(address[] memory _accounts, uint256[] memory _amounts) external nonReentrant onlyGov {
+        address _gmx = gmx;
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            _stakeGmx(msg.sender, _accounts[i], _gmx, _amounts[i]);
+        }
+    }
+
+    function batchCompoundForAccounts(address[] memory _accounts) external nonReentrant onlyGov {
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            _compound(_accounts[i]);
+        }
+    }
+
+    function batchRestakeForAccounts(address[] memory _accounts) external nonReentrant onlyGov {
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            _restakeForAccount(_accounts[i]);
+        }
+    }
+
+    function multicall(bytes[] memory data) external returns (bytes[] memory results) {
+        results = new bytes[](data.length);
+
+        for (uint256 i; i < data.length; i++) {
+            (bool success, bytes memory result) = address(this).delegatecall(data[i]);
+
+            require(success, "call failed");
+
+            results[i] = result;
+        }
+
+        return results;
+    }
+
+    function makeExternalCalls(
+        address[] memory externalCallTargets,
+        bytes[] memory externalCallDataList,
+        address[] memory refundTokens,
+        address[] memory refundReceivers
+    ) external nonReentrant {
+        IExternalHandler(externalHandler).makeExternalCalls(
+            externalCallTargets,
+            externalCallDataList,
+            refundTokens,
+            refundReceivers
+        );
+    }
+
+    function stakeGmx(uint256 _amount) external nonReentrant {
+        _stakeGmx(msg.sender, msg.sender, gmx, _amount);
+    }
+
+    function stakeEsGmx(uint256 _amount) external nonReentrant {
+        _stakeGmx(msg.sender, msg.sender, esGmx, _amount);
+    }
+
+    function unstakeGmx(uint256 _amount) external nonReentrant {
+        _restakeForAccount(msg.sender);
+
+        _unstakeGmx(msg.sender, gmx, _amount, true);
+    }
+
+    function unstakeEsGmx(uint256 _amount) external nonReentrant {
+        _restakeForAccount(msg.sender);
+
+        _unstakeGmx(msg.sender, esGmx, _amount, true);
+    }
+
+    function claim() external nonReentrant {
+        _claim(stakedGmxTracker, stakedGlpTracker, msg.sender, msg.sender);
+        _claimGmxFees(msg.sender, msg.sender);
+        _claim(feeGmxTracker, feeGlpTracker, msg.sender, msg.sender);
+    }
+
+    function claimEsGmx() external nonReentrant {
+        _claim(stakedGmxTracker, stakedGlpTracker, msg.sender, msg.sender);
+    }
+
+    function claimFees() external nonReentrant {
+        _claimGmxFees(msg.sender, msg.sender);
+        _claim(feeGmxTracker, feeGlpTracker, msg.sender, msg.sender);
+    }
+
+    function compound() external nonReentrant {
+        _compound(msg.sender);
+    }
+
+    function vesterDeposit(address _vester, uint256 _amount) external nonReentrant {
+        _validateDesignatedVester(_vester);
+        IRatioVester(_vester).depositForAccount(msg.sender, _amount);
+    }
+
+    function vesterWithdraw(address _vester) external nonReentrant {
+        _validateDesignatedVester(_vester);
+        IRatioVester(_vester).withdrawForAccount(msg.sender);
+    }
+
+    function vesterClaim(address _vester) external nonReentrant returns (uint256) {
+        _validateDesignatedVester(_vester);
+        return IRatioVester(_vester).claimForAccount(msg.sender);
+    }
+
+    function issuerClaim() external nonReentrant returns (uint256) {
+        require(esGmxIssuer != address(0), "issuer not set");
+        return IEsGmxIssuer(esGmxIssuer).claimForAccount(msg.sender);
+    }
+
+    function handleRewards(
+        bool _shouldClaimGmx,
+        bool _shouldStakeGmx,
+        bool _shouldClaimEsGmx,
+        bool _shouldStakeEsGmx,
+        bool _shouldStakeMultiplierPoints,
+        bool _shouldClaimWeth,
+        bool _shouldConvertWethToEth
+    ) external nonReentrant {
+        _handleRewards(
+            msg.sender,
+            _shouldClaimGmx,
+            _shouldStakeGmx,
+            _shouldClaimEsGmx,
+            _shouldStakeEsGmx,
+            _shouldStakeMultiplierPoints,
+            _shouldClaimWeth,
+            _shouldConvertWethToEth
+        );
+    }
+
+    function handleRewardsV2(
+        address _gmxReceiver,
+        bool _shouldClaimGmx,
+        bool _shouldStakeGmx,
+        bool _shouldClaimEsGmx,
+        bool _shouldStakeEsGmx,
+        bool _shouldStakeMultiplierPoints,
+        bool _shouldClaimWeth,
+        bool _shouldConvertWethToEth
+    ) external nonReentrant {
+        _handleRewards(
+            _gmxReceiver,
+            _shouldClaimGmx,
+            _shouldStakeGmx,
+            _shouldClaimEsGmx,
+            _shouldStakeEsGmx,
+            _shouldStakeMultiplierPoints,
+            _shouldClaimWeth,
+            _shouldConvertWethToEth
+        );
+    }
+
+    function _handleRewards(
+        address _gmxReceiver,
+        bool _shouldClaimGmx,
+        bool _shouldStakeGmx,
+        bool _shouldClaimEsGmx,
+        bool _shouldStakeEsGmx,
+        bool _shouldStakeMultiplierPoints,
+        bool _shouldClaimWeth,
+        bool _shouldConvertWethToEth
+    ) private {
+        address account = msg.sender;
+
+        uint256 gmxAmount = 0;
+        if (_shouldClaimGmx) {
+            uint256 gmxAmount0 = _claimVestedGmx(account, _gmxReceiver);
+            uint256 gmxAmount1 = _claimGmxFees(account, _gmxReceiver);
+            gmxAmount = gmxAmount0.add(gmxAmount1);
+        }
+
+        if (_shouldStakeGmx && gmxAmount > 0) {
+            require(_gmxReceiver == account, "invalid _gmxReceiver");
+            _stakeGmx(account, account, gmx, gmxAmount);
+        }
+
+        uint256 esGmxAmount = 0;
+        if (_shouldClaimEsGmx) {
+            esGmxAmount = _claim(stakedGmxTracker, stakedGlpTracker, account, account);
+        }
+
+        if (_shouldStakeEsGmx && esGmxAmount > 0) {
+            _stakeGmx(account, account, esGmx, esGmxAmount);
+        }
+
+        if (_shouldStakeMultiplierPoints) {
+            _restakeForAccount(account);
+
+            _stakeBnGmx(account);
+        }
+
+        if (_shouldClaimWeth) {
+            if (_shouldConvertWethToEth) {
+                uint256 wethAmount = _claim(feeGmxTracker, feeGlpTracker, account, address(this));
+                _convertWethToEth(wethAmount);
+            } else {
+                _claim(feeGmxTracker, feeGlpTracker, account, account);
+            }
+        }
+
+        _syncVotingPower(account);
+    }
+
+    // the _validateReceiver function checks that the averageStakedAmounts and cumulativeRewards
+    // values of an account are zero, this is to help ensure that vesting calculations can be
+    // done correctly
+    // averageStakedAmounts and cumulativeRewards are updated if the claimable reward for an account
+    // is more than zero
+    // it is possible for multiple transfers to be sent into a single account, using signalTransfer and
+    // acceptTransfer, if those values have not been updated yet
+    // for GLP transfers it is also possible to transfer GLP into an account using the StakedGlp contract
+    function signalTransfer(address _receiver) external nonReentrant {
+        require(designatedVesters.length > 0, "no designated vesters");
+
+        _validateSender(msg.sender);
+
+        _validateReceiver(_receiver);
+
+        if (inStrictTransferMode) {
+            uint256 balance = IRewardTracker(feeGmxTracker).stakedAmounts(msg.sender);
+            uint256 allowance = IERC20(feeGmxTracker).allowance(msg.sender, _receiver);
+            require(allowance >= balance, "insufficient allowance");
+        }
+
+        pendingReceivers[msg.sender] = _receiver;
+    }
+
+    function acceptTransfer(address _sender) external nonReentrant {
+        require(designatedVesters.length > 0, "no designated vesters");
+
+        _validateSender(_sender);
+
+        address receiver = msg.sender;
+        require(pendingReceivers[_sender] == receiver, "transfer not signalled");
+        delete pendingReceivers[_sender];
+
+        _validateReceiver(receiver);
+        _compound(_sender);
+
+        uint256 stakedGmx = IRewardTracker(stakedGmxTracker).depositBalances(_sender, gmx);
+        if (stakedGmx > 0) {
+            _unstakeGmx(_sender, gmx, stakedGmx, false);
+            _stakeGmx(_sender, receiver, gmx, stakedGmx);
+        }
+
+        uint256 stakedEsGmx = IRewardTracker(stakedGmxTracker).depositBalances(_sender, esGmx);
+        if (stakedEsGmx > 0) {
+            _unstakeGmx(_sender, esGmx, stakedEsGmx, false);
+            _stakeGmx(_sender, receiver, esGmx, stakedEsGmx);
+        }
+
+        uint256 stakedBnGmx = IRewardTracker(extendedGmxTracker).depositBalances(_sender, bnGmx);
+        _acceptTransferRestake(feeGmxTracker, extendedGmxTracker, _sender, receiver, bnGmx, stakedBnGmx);
+
+        // pending issuance is claimed to the sender before the wallet esGMX sweep;
+        // an unpayable pending claim reverts here and blocks the transfer rather than stranding tokens
+        for (uint256 i = 0; i < designatedVesters.length; i++) {
+            address vesterIssuer = IRatioVester(designatedVesters[i]).issuer();
+            if (vesterIssuer == address(0)) { continue; }
+            if (IEsGmxIssuer(vesterIssuer).claimable(_sender) == 0) { continue; }
+            IEsGmxIssuer(vesterIssuer).claimForAccount(_sender);
+        }
+
+        uint256 esGmxBalance = IERC20(esGmx).balanceOf(_sender);
+        if (esGmxBalance > 0) {
+            IERC20(esGmx).transferFrom(_sender, receiver, esGmxBalance);
+        }
+
+        uint256 bnGmxBalance = IERC20(bnGmx).balanceOf(_sender);
+        if (bnGmxBalance > 0) {
+            _burnToken(bnGmx, _sender, bnGmxBalance);
+            _mintToken(bnGmx, receiver, bnGmxBalance);
+        }
+
+        uint256 glpAmount = IRewardTracker(feeGlpTracker).depositBalances(_sender, glp);
+        _acceptTransferRestake(stakedGlpTracker, feeGlpTracker, _sender, receiver, glp, glpAmount);
+
+        for (uint256 i = 0; i < designatedVesters.length; i++) {
+            IRatioVester(designatedVesters[i]).transferVestingState(_sender, receiver);
+        }
+
+        _syncVotingPower(_sender);
+        _syncVotingPower(receiver);
+    }
+
+    function _claim(address _rewardTracker0, address _rewardTracker1, address _account, address _receiver) private returns (uint256) {
+        uint256 amount0 = IRewardTracker(_rewardTracker0).claimForAccount(_account, _receiver);
+        uint256 amount1 = IRewardTracker(_rewardTracker1).claimForAccount(_account, _receiver);
+        uint256 amount = amount0.add(amount1);
+        return(amount);
+    }
+
+    function _claimGmxFees(address _account, address _receiver) private returns (uint256) {
+        uint256 gmxAmount = IRewardTracker(extendedGmxTracker).claimForAccount(_account, _receiver);
+        return(gmxAmount);
+    }
+
+    // the designated vesters pay the account itself, so vested GMX is only claimed
+    // when the receiver is the account; the legacy vesters are not proxied
+    function _claimVestedGmx(address _account, address _receiver) private returns (uint256) {
+        if (_receiver != _account) { return 0; }
+        uint256 gmxAmount = 0;
+        for (uint256 i = 0; i < designatedVesters.length; i++) {
+            IRatioVester designatedVester = IRatioVester(designatedVesters[i]);
+            // skip rather than revert so handleRewards stays usable while a handler grant
+            // is withheld (migration steps 5-8) or the account is frozen on one vester
+            if (!designatedVester.isHandler(address(this))) { continue; }
+            if (designatedVester.isFrozen(_account)) { continue; }
+            gmxAmount = gmxAmount.add(designatedVester.claimForAccount(_account));
+        }
+        return (gmxAmount);
+    }
+
+    function _convertWethToEth(uint256 _amount) private {
+        IWETH(weth).withdraw(_amount);
+        payable(msg.sender).sendValue(_amount);
+    }
+
+    function _compound(address _account) private {
+        uint256 gmxAmount = _claimGmxFees(_account, _account);
+        if (gmxAmount > 0) {
+            _stakeGmx(_account, _account, gmx, gmxAmount);
+        }
+
+        uint256 esGmxAmount = _claim(stakedGmxTracker, stakedGlpTracker, _account, _account);
+        if (esGmxAmount > 0) {
+            _stakeGmx(_account, _account, esGmx, esGmxAmount);
+        }
+
+        _restakeForAccount(_account);
+
+        _stakeBnGmx(_account);
+
+        _syncVotingPower(_account);
+    }
+
+    function _stakeGmx(address _fundingAccount, address _account, address _token, uint256 _amount) private {
+        _validateAmount(_amount);
+
+        IRewardTracker(stakedGmxTracker).stakeForAccount(_fundingAccount, _account, _token, _amount);
+        IRewardTracker(bonusGmxTracker).stakeForAccount(_account, _account, stakedGmxTracker, _amount);
+        IRewardTracker(extendedGmxTracker).stakeForAccount(_account, _account, bonusGmxTracker, _amount);
+        IRewardTracker(feeGmxTracker).stakeForAccount(_account, _account, extendedGmxTracker, _amount);
+
+        _syncVotingPower(_account);
+
+        emit StakeGmx(_account, _token, _amount);
+    }
+
+    // note that _syncVotingPower is not called here, in functions which
+    // call _stakeBnGmx it should be ensured that _syncVotingPower is called
+    // after
+    function _stakeBnGmx(address _account) private {
+        IRewardTracker(bonusGmxTracker).claimForAccount(_account, _account);
+
+        // get the bnGmx balance of the user, this would be the amount of
+        // bnGmx that has not been staked
+        uint256 bnGmxAmount = IERC20(bnGmx).balanceOf(_account);
+        if (bnGmxAmount == 0) { return; }
+
+        // get the baseStakedAmount which would be the sum of staked gmx and staked esGmx tokens
+        uint256 baseStakedAmount = IRewardTracker(stakedGmxTracker).stakedAmounts(_account);
+        uint256 maxAllowedBnGmxAmount = baseStakedAmount.mul(maxBoostBasisPoints).div(BASIS_POINTS_DIVISOR);
+        uint256 currentBnGmxAmount = IRewardTracker(extendedGmxTracker).depositBalances(_account, bnGmx);
+        if (currentBnGmxAmount == maxAllowedBnGmxAmount) { return; }
+
+        // if the currentBnGmxAmount is more than the maxAllowedBnGmxAmount
+        // unstake the excess tokens
+        if (currentBnGmxAmount > maxAllowedBnGmxAmount) {
+            uint256 amountToUnstake = currentBnGmxAmount.sub(maxAllowedBnGmxAmount);
+            IRewardTracker(feeGmxTracker).unstakeForAccount(_account, extendedGmxTracker, amountToUnstake, _account);
+            IRewardTracker(extendedGmxTracker).unstakeForAccount(_account, bnGmx, amountToUnstake, _account);
+            return;
+        }
+
+        uint256 maxStakeableBnGmxAmount = maxAllowedBnGmxAmount.sub(currentBnGmxAmount);
+        if (bnGmxAmount > maxStakeableBnGmxAmount) {
+            bnGmxAmount = maxStakeableBnGmxAmount;
+        }
+
+        IRewardTracker(extendedGmxTracker).stakeForAccount(_account, _account, bnGmx, bnGmxAmount);
+        IRewardTracker(feeGmxTracker).stakeForAccount(_account, _account, extendedGmxTracker, bnGmxAmount);
+    }
+
+    function _unstakeGmx(address _account, address _token, uint256 _amount, bool _shouldReduceBnGmx) private {
+        _validateAmount(_amount);
+
+        uint256 balance = IRewardTracker(stakedGmxTracker).stakedAmounts(_account);
+
+        IRewardTracker(feeGmxTracker).unstakeForAccount(_account, extendedGmxTracker, _amount, _account);
+        IRewardTracker(extendedGmxTracker).unstakeForAccount(_account, bonusGmxTracker, _amount, _account);
+        IRewardTracker(bonusGmxTracker).unstakeForAccount(_account, stakedGmxTracker, _amount, _account);
+        IRewardTracker(stakedGmxTracker).unstakeForAccount(_account, _token, _amount, _account);
+
+        if (_shouldReduceBnGmx) {
+            IRewardTracker(bonusGmxTracker).claimForAccount(_account, _account);
+
+            // unstake and burn staked bnGmx tokens
+            uint256 stakedBnGmx = IRewardTracker(extendedGmxTracker).depositBalances(_account, bnGmx);
+            if (stakedBnGmx > 0) {
+                uint256 reductionAmount = stakedBnGmx.mul(_amount).div(balance);
+                IRewardTracker(feeGmxTracker).unstakeForAccount(_account, extendedGmxTracker, reductionAmount, _account);
+                IRewardTracker(extendedGmxTracker).unstakeForAccount(_account, bnGmx, reductionAmount, _account);
+                _burnToken(bnGmx, _account, reductionAmount);
+            }
+
+            // burn bnGmx tokens from user's balance
+            uint256 bnGmxBalance = IERC20(bnGmx).balanceOf(_account);
+            if (bnGmxBalance > 0) {
+                uint256 amountToBurn = bnGmxBalance.mul(_amount).div(balance);
+                _burnToken(bnGmx, _account, amountToBurn);
+            }
+        }
+
+        _syncVotingPower(_account);
+
+        emit UnstakeGmx(_account, _token, _amount);
+    }
+
+    function _syncVotingPower(address _account) private {
+        if (votingPowerType == VotingPowerType.None) {
+            return;
+        }
+
+        if (votingPowerType == VotingPowerType.BaseStakedAmount) {
+            uint256 baseStakedAmount = IRewardTracker(stakedGmxTracker).stakedAmounts(_account);
+            _syncVotingPower(_account, baseStakedAmount);
+            return;
+        }
+
+        if (votingPowerType == VotingPowerType.BaseAndBonusStakedAmount) {
+            uint256 stakedAmount = IRewardTracker(feeGmxTracker).stakedAmounts(_account);
+            _syncVotingPower(_account, stakedAmount);
+            return;
+        }
+
+        revert("unsupported votingPowerType");
+    }
+
+    function _syncVotingPower(address _account, uint256 _amount) private {
+        uint256 currentVotingPower = IERC20(govToken).balanceOf(_account);
+        if (currentVotingPower == _amount) { return; }
+
+        if (currentVotingPower > _amount) {
+            uint256 amountToBurn = currentVotingPower.sub(_amount);
+            _burnToken(govToken, _account, amountToBurn);
+            return;
+        }
+
+        uint256 amountToMint = _amount.sub(currentVotingPower);
+        _mintToken(govToken, _account, amountToMint);
+    }
+
+    function _restakeForAccount(address _account) private {
+        if (!inRestakingMode) { return; }
+
+        uint256 bonusGmxTrackerBalance = IRewardTracker(feeGmxTracker).depositBalances(_account, bonusGmxTracker);
+        if (bonusGmxTrackerBalance > 0) {
+            uint256 reservedForVesting = IVester(gmxVester).pairAmounts(_account);
+            if (reservedForVesting > 0) {
+                IERC20(feeGmxTracker).safeTransferFrom(gmxVester, _account, reservedForVesting);
+                _restakeBonusGmxTracker(_account, bonusGmxTrackerBalance);
+                _restakeBnGmx(_account);
+                IERC20(feeGmxTracker).safeTransferFrom(_account, gmxVester, reservedForVesting);
+            }
+            else {
+                _restakeBonusGmxTracker(_account, bonusGmxTrackerBalance);
+                _restakeBnGmx(_account);
+            }
+        }
+    }
+
+    function _restakeBonusGmxTracker(address _account, uint256 _bonusGmxTrackerBalance) private {
+        IRewardTracker(feeGmxTracker).unstakeForAccount(_account, bonusGmxTracker, _bonusGmxTrackerBalance, _account);
+        IRewardTracker(extendedGmxTracker).stakeForAccount(_account, _account, bonusGmxTracker, _bonusGmxTrackerBalance);
+        IRewardTracker(feeGmxTracker).stakeForAccount(_account, _account, extendedGmxTracker, _bonusGmxTrackerBalance);
+    }
+
+    function _restakeBnGmx(address _account) private {
+        uint256 stakedBnGmx = IRewardTracker(feeGmxTracker).depositBalances(_account, bnGmx);
+        if (stakedBnGmx > 0) {
+            IRewardTracker(feeGmxTracker).unstakeForAccount(_account, bnGmx, stakedBnGmx, _account);
+            _stakeBnGmx(_account);
+            _syncVotingPower(_account);
+        }
+    }
+
+    function _acceptTransferRestake(address _rewardTracker0, address _rewardTracker1, address _sender, address _receiver, address _token, uint256 _amount) private {
+        if (_amount > 0) {
+            IRewardTracker(_rewardTracker0).unstakeForAccount(_sender, _rewardTracker1, _amount, _sender);
+            IRewardTracker(_rewardTracker1).unstakeForAccount(_sender, _token, _amount, _sender);
+            IRewardTracker(_rewardTracker1).stakeForAccount(_sender, _receiver, _token, _amount);
+            IRewardTracker(_rewardTracker0).stakeForAccount(_receiver, _receiver, _rewardTracker1, _amount);
+        }
+    }
+
+    function _mintToken(address _token, address _account, uint256 _amountToMint) private {
+        IMintable(_token).mint(_account, _amountToMint);
+    }
+
+    function _burnToken(address _token, address _account, uint256 _amountToBurn) private {
+        IMintable(_token).burn(_account, _amountToBurn);
+    }
+
+    function _validateReceiver(address _receiver) private view {
+        address[6] memory trackers = [stakedGmxTracker, bonusGmxTracker, extendedGmxTracker, feeGmxTracker, stakedGlpTracker, feeGlpTracker];
+        for (uint256 i = 0; i < trackers.length; i++) {
+            require(IRewardTracker(trackers[i]).averageStakedAmounts(_receiver) == 0, "receiver tracker not fresh");
+            require(IRewardTracker(trackers[i]).cumulativeRewards(_receiver) == 0, "receiver tracker not fresh");
+        }
+
+        address[2] memory legacyVesters = [gmxVester, glpVester];
+        for (uint256 i = 0; i < legacyVesters.length; i++) {
+            require(IVester(legacyVesters[i]).transferredAverageStakedAmounts(_receiver) == 0, "receiver vester not fresh");
+            require(IVester(legacyVesters[i]).transferredCumulativeRewards(_receiver) == 0, "receiver vester not fresh");
+            require(IERC20(legacyVesters[i]).balanceOf(_receiver) == 0, "receiver vester not fresh");
+        }
+
+        for (uint256 i = 0; i < designatedVesters.length; i++) {
+            require(IRatioVester(designatedVesters[i]).isFreshForTransfer(_receiver), "receiver not fresh");
+        }
+    }
+
+    function _validateSender(address _sender) private view {
+        _validateNotVesting(_sender);
+
+        require(IVester(gmxVester).pairAmounts(_sender) == 0 && IVester(glpVester).pairAmounts(_sender) == 0, "sender has pair amounts");
+
+        for (uint256 i = 0; i < designatedVesters.length; i++) {
+            require(!IRatioVester(designatedVesters[i]).hasOpenSession(_sender), "sender has open session");
+        }
+    }
+
+    function _validateNotVesting(address _sender) private view {
+        require(IERC20(gmxVester).balanceOf(_sender) == 0 && IERC20(glpVester).balanceOf(_sender) == 0, "sender has vested tokens");
+    }
+
+    function _validateAmount(uint256 _amount) private pure {
+        require(_amount > 0, "invalid _amount");
+    }
+
+    function _validateDesignatedVester(address _vester) private view {
+        require(isDesignatedVester[_vester], "invalid vester");
+    }
+}

--- a/contracts/staking/VesterCapZeroer.sol
+++ b/contracts/staking/VesterCapZeroer.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+import "../libraries/math/SafeMath.sol";
+import "../libraries/utils/ReentrancyGuard.sol";
+
+import "./interfaces/IVester.sol";
+import "./interfaces/IRewardTracker.sol";
+import "../access/Guardable.sol";
+
+contract VesterCapZeroer is ReentrancyGuard, Guardable {
+    using SafeMath for uint256;
+
+    address public vester;
+    address public rewardTracker;
+
+    mapping (address => bool) public isKeeper;
+
+    event CapZeroed(address account, uint256 deduction);
+
+    constructor(address _vester) public {
+        vester = _vester;
+        rewardTracker = IVester(_vester).rewardTracker();
+    }
+
+    function setKeeper(address _keeper, bool _isActive) external onlyCapsAdmin {
+        isKeeper[_keeper] = _isActive;
+    }
+
+    function zeroCaps(address[] calldata _accounts) external nonReentrant {
+        require(isKeeper[msg.sender], "VesterCapZeroer: forbidden");
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            address account = _accounts[i];
+            if (IVester(vester).getMaxVestableAmount(account) == 0) { continue; }
+            uint256 deduction = getPositiveTerms(account);
+            IVester(vester).setCumulativeRewardDeductions(account, deduction);
+            emit CapZeroed(account, deduction);
+        }
+    }
+
+    function getPositiveTerms(address _account) public view returns (uint256) {
+        // claimable() includes accrual not yet materialized into cumulativeRewards; counting it
+        // over-deducts by the already-materialized part, which only adds margin to a permanent closure
+        return IRewardTracker(rewardTracker).cumulativeRewards(_account)
+            .add(IRewardTracker(rewardTracker).claimable(_account))
+            .add(IVester(vester).transferredCumulativeRewards(_account))
+            .add(IVester(vester).bonusRewards(_account));
+    }
+
+    function isZeroed(address _account) external view returns (bool) {
+        return IVester(vester).getMaxVestableAmount(_account) == 0;
+    }
+}

--- a/contracts/staking/interfaces/IEsGmxIssuer.sol
+++ b/contracts/staking/interfaces/IEsGmxIssuer.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IEsGmxIssuer {
+    function vester() external view returns (address);
+    function issuedAmounts(address _account) external view returns (uint256);
+    function claimable(address _account) external view returns (uint256);
+    function claimForAccount(address _account) external returns (uint256);
+}

--- a/contracts/staking/interfaces/IRatioVester.sol
+++ b/contracts/staking/interfaces/IRatioVester.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+
+interface IRatioVester {
+    function issuer() external view returns (address);
+    function isHandler(address _account) external view returns (bool);
+    function isFrozen(address _account) external view returns (bool);
+    function pairAmounts(address _account) external view returns (uint256);
+    function getVestingCap(address _account) external view returns (uint256);
+    function claimable(address _account) external view returns (uint256);
+    function hasOpenSession(address _account) external view returns (bool);
+    function isFreshForTransfer(address _account) external view returns (bool);
+    function depositForAccount(address _account, uint256 _amount) external;
+    function withdrawForAccount(address _account) external;
+    function claimForAccount(address _account) external returns (uint256);
+    function transferVestingState(address _sender, address _receiver) external;
+}

--- a/test/peripherals/RatioVesterReader.js
+++ b/test/peripherals/RatioVesterReader.js
@@ -1,0 +1,103 @@
+const { expect, use } = require("chai")
+const { solidity } = require("ethereum-waffle")
+const { deployContract } = require("../shared/fixtures")
+const { expandDecimals, increaseTime, mineBlock } = require("../shared/utilities")
+
+use(solidity)
+
+const { AddressZero } = ethers.constants
+const secondsPerYear = 365 * 24 * 60 * 60
+const PAIR_PRECISION = expandDecimals(1, 30)
+
+describe("RatioVesterReader", function () {
+  const provider = waffle.provider
+  const [wallet, user0, capsAdmin, distributor] = provider.getWallets()
+  let esGmx, gmx, pair
+  let issuer, vester, reader
+
+  beforeEach(async () => {
+    esGmx = await deployContract("EsGMX", [])
+    gmx = await deployContract("Token", [])
+    pair = await deployContract("Token", [])
+
+    issuer = await deployContract("EsGmxIssuer", [esGmx.address])
+    vester = await deployContract("RatioVester", [
+      "Vested GMX S1", "vGMX-S1", secondsPerYear, esGmx.address, pair.address, gmx.address,
+      issuer.address, PAIR_PRECISION.mul(5), false
+    ])
+    reader = await deployContract("RatioVesterReader", [])
+
+    await esGmx.setMinter(wallet.address, true)
+    await esGmx.setMinter(vester.address, true)
+    await issuer.setCapsAdmin(capsAdmin.address)
+    await issuer.connect(capsAdmin).setDistributor(distributor.address, true)
+    await issuer.setVester(vester.address)
+    await vester.confirmIssuerBinding()
+
+    await esGmx.mint(issuer.address, expandDecimals(10000, 18))
+    await gmx.mint(vester.address, expandDecimals(10000, 18))
+  })
+
+  const issueAndDeposit = async (amount, batch) => {
+    await issuer.connect(distributor).distributeEpoch(1, batch, [user0.address], [amount])
+    await issuer.connect(user0).claim()
+    await esGmx.connect(user0).approve(vester.address, amount)
+    const pairAmount = amount.mul(5)
+    await pair.mint(user0.address, pairAmount)
+    await pair.connect(user0).approve(vester.address, pairAmount)
+    await vester.connect(user0).deposit(amount)
+  }
+
+  it("returns the vesting summary per vester", async () => {
+    await issueAndDeposit(expandDecimals(100, 18), 0)
+
+    await increaseTime(provider, 73 * 24 * 60 * 60)
+    await mineBlock(provider)
+
+    const info = await reader.getVestingInfo([vester.address], user0.address)
+    expect(info.length).eq(12)
+    expect(info[0]).eq(expandDecimals(100, 18))
+    expect(info[1]).eq(expandDecimals(500, 18))
+    expect(info[2]).gt(expandDecimals(19, 18))
+    expect(info[2]).lt(expandDecimals(21, 18))
+    expect(info[7]).eq(expandDecimals(100, 18))
+    expect(info[8]).eq(1)
+    expect(info[9]).eq(secondsPerYear)
+    expect(info[10]).eq(0)
+    expect(info[11]).eq(PAIR_PRECISION.mul(5))
+  })
+
+  it("returns live tranches and drops them after withdrawal", async () => {
+    await issueAndDeposit(expandDecimals(100, 18), 0)
+    await increaseTime(provider, 8 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await issueAndDeposit(expandDecimals(50, 18), 1)
+
+    let result = await reader.getTranches(vester.address, user0.address)
+    expect(result.startTimes.length).eq(2)
+    expect(result.totalAmounts[0]).eq(expandDecimals(100, 18))
+    expect(result.totalAmounts[1]).eq(expandDecimals(50, 18))
+    expect(result.startTimes[1]).gt(result.startTimes[0])
+
+    await vester.connect(user0).withdraw()
+    result = await reader.getTranches(vester.address, user0.address)
+    expect(result.startTimes.length).eq(0)
+  })
+
+  it("returns issuer info", async () => {
+    await issuer.connect(distributor).distributeEpoch(1, 0, [user0.address], [expandDecimals(300, 18)])
+
+    let info = await reader.getIssuerInfo(issuer.address, user0.address)
+    expect(info[0]).eq(expandDecimals(300, 18))
+    expect(info[1]).eq(0)
+    expect(info[2]).eq(expandDecimals(300, 18))
+    expect(info[3]).eq(expandDecimals(300, 18))
+    expect(info[4]).eq(0)
+
+    await issuer.connect(user0).claim()
+    info = await reader.getIssuerInfo(issuer.address, user0.address)
+    expect(info[1]).eq(expandDecimals(300, 18))
+    expect(info[2]).eq(0)
+    expect(info[4]).eq(expandDecimals(300, 18))
+  })
+})

--- a/test/staking/EsGmxIssuer.js
+++ b/test/staking/EsGmxIssuer.js
@@ -1,0 +1,212 @@
+const { expect, use } = require("chai")
+const { solidity } = require("ethereum-waffle")
+const { deployContract } = require("../shared/fixtures")
+const { expandDecimals } = require("../shared/utilities")
+
+use(solidity)
+
+const { AddressZero } = ethers.constants
+
+describe("EsGmxIssuer", function () {
+  const provider = waffle.provider
+  const [wallet, user0, user1, user2, capsAdmin, guardian, distributor] = provider.getWallets()
+  let esGmx
+  let issuer
+  let sorted
+
+  beforeEach(async () => {
+    esGmx = await deployContract("EsGMX", [])
+    issuer = await deployContract("EsGmxIssuer", [esGmx.address])
+
+    await esGmx.setMinter(wallet.address, true)
+    await issuer.setCapsAdmin(capsAdmin.address)
+    await issuer.setGuardian(guardian.address)
+    await issuer.connect(capsAdmin).setDistributor(distributor.address, true)
+
+    sorted = [user0.address, user1.address, user2.address].sort((a, b) =>
+      a.toLowerCase() < b.toLowerCase() ? -1 : 1
+    )
+  })
+
+  it("inits and gates roles", async () => {
+    expect(await issuer.esGmx()).eq(esGmx.address)
+    expect(await issuer.vester()).eq(AddressZero)
+    expect(await issuer.gov()).eq(wallet.address)
+    expect(await issuer.capsAdmin()).eq(capsAdmin.address)
+    expect(await issuer.guardian()).eq(guardian.address)
+    expect(await issuer.isDistributor(distributor.address)).eq(true)
+
+    await expect(issuer.connect(user0).setDistributor(user0.address, true))
+      .to.be.revertedWith("Guardable: forbidden")
+    await expect(issuer.connect(user0).setClaimsPaused(true))
+      .to.be.revertedWith("Guardable: forbidden")
+    await expect(issuer.connect(user0).setHandler(user0.address, true))
+      .to.be.revertedWith("Governable: forbidden")
+    await expect(issuer.connect(user0).setVester(user0.address))
+      .to.be.revertedWith("Governable: forbidden")
+    await expect(issuer.connect(user0).withdrawToken(esGmx.address, user0.address, 1))
+      .to.be.revertedWith("Governable: forbidden")
+    await expect(issuer.connect(user0).finalizeEpoch(1, 0, 0))
+      .to.be.revertedWith("Guardable: forbidden")
+    await expect(issuer.connect(user0).reduceIssuedAmount(user0.address, 1))
+      .to.be.revertedWith("Guardable: forbidden")
+  })
+
+  it("setVester is one-shot", async () => {
+    await expect(issuer.setVester(AddressZero))
+      .to.be.revertedWith("EsGmxIssuer: invalid vester")
+    await issuer.setVester(user1.address)
+    expect(await issuer.vester()).eq(user1.address)
+    await expect(issuer.setVester(user2.address))
+      .to.be.revertedWith("EsGmxIssuer: vester already set")
+  })
+
+  it("distributeEpoch validates inputs and funding", async () => {
+    await expect(issuer.connect(user0).distributeEpoch(1, 0, [sorted[0]], [100]))
+      .to.be.revertedWith("EsGmxIssuer: forbidden")
+    await expect(issuer.connect(distributor).distributeEpoch(1, 0, [], []))
+      .to.be.revertedWith("EsGmxIssuer: empty batch")
+    await expect(issuer.connect(distributor).distributeEpoch(1, 0, [sorted[0]], [100, 200]))
+      .to.be.revertedWith("EsGmxIssuer: invalid input lengths")
+    await expect(issuer.connect(distributor).distributeEpoch(1, 0, [sorted[1], sorted[0]], [100, 200]))
+      .to.be.revertedWith("EsGmxIssuer: accounts not sorted")
+    await expect(issuer.connect(distributor).distributeEpoch(1, 0, [sorted[0], sorted[0]], [100, 200]))
+      .to.be.revertedWith("EsGmxIssuer: accounts not sorted")
+    await expect(issuer.connect(distributor).distributeEpoch(1, 0, [AddressZero], [100]))
+      .to.be.revertedWith("EsGmxIssuer: invalid account")
+    await expect(issuer.connect(distributor).distributeEpoch(1, 0, [sorted[0]], [0]))
+      .to.be.revertedWith("EsGmxIssuer: invalid amount")
+
+    await expect(issuer.connect(distributor).distributeEpoch(1, 0, [sorted[0]], [100]))
+      .to.be.revertedWith("EsGmxIssuer: insufficient esGMX for issuance")
+
+    await esGmx.mint(issuer.address, 1000)
+    await issuer.connect(distributor).distributeEpoch(1, 0, [sorted[0], sorted[1]], [100, 200])
+
+    expect(await issuer.issuedAmounts(sorted[0])).eq(100)
+    expect(await issuer.issuedAmounts(sorted[1])).eq(200)
+    expect(await issuer.claimable(sorted[0])).eq(100)
+    expect(await issuer.totalIssuedAmount()).eq(300)
+
+    const epoch = await issuer.epochs(1)
+    expect(epoch.finalized).eq(false)
+    expect(epoch.entryCount).eq(2)
+    expect(epoch.totalAmount).eq(300)
+
+    await expect(issuer.connect(distributor).distributeEpoch(1, 1, [sorted[0]], [800]))
+      .to.be.revertedWith("EsGmxIssuer: insufficient esGMX for issuance")
+    await issuer.connect(distributor).distributeEpoch(1, 1, [sorted[0]], [700])
+    expect(await issuer.totalIssuedAmount()).eq(1000)
+  })
+
+  it("closes both replay shapes, scoped per epoch", async () => {
+    await esGmx.mint(issuer.address, 1000)
+    await issuer.connect(distributor).distributeEpoch(1, 0, [sorted[0]], [100])
+
+    await expect(issuer.connect(distributor).distributeEpoch(1, 0, [sorted[1]], [100]))
+      .to.be.revertedWith("EsGmxIssuer: batch index already processed")
+    await expect(issuer.connect(distributor).distributeEpoch(1, 1, [sorted[0]], [100]))
+      .to.be.revertedWith("EsGmxIssuer: batch content already processed")
+
+    await issuer.connect(distributor).distributeEpoch(1, 1, [sorted[0]], [150])
+    await issuer.connect(distributor).distributeEpoch(2, 0, [sorted[0]], [100])
+
+    expect(await issuer.issuedAmounts(sorted[0])).eq(350)
+  })
+
+  it("finalizeEpoch reconciles and seals", async () => {
+    await esGmx.mint(issuer.address, 1000)
+    await issuer.connect(distributor).distributeEpoch(1, 0, [sorted[0], sorted[1]], [100, 200])
+
+    await expect(issuer.connect(capsAdmin).finalizeEpoch(1, 1, 300))
+      .to.be.revertedWith("EsGmxIssuer: entry count mismatch")
+    await expect(issuer.connect(capsAdmin).finalizeEpoch(1, 2, 299))
+      .to.be.revertedWith("EsGmxIssuer: total amount mismatch")
+    await expect(issuer.connect(capsAdmin).finalizeEpoch(2, 1, 100))
+      .to.be.revertedWith("EsGmxIssuer: entry count mismatch")
+
+    await issuer.connect(capsAdmin).finalizeEpoch(1, 2, 300)
+    expect((await issuer.epochs(1)).finalized).eq(true)
+
+    await expect(issuer.connect(capsAdmin).finalizeEpoch(1, 2, 300))
+      .to.be.revertedWith("EsGmxIssuer: epoch finalized")
+    await expect(issuer.connect(distributor).distributeEpoch(1, 2, [sorted[2]], [50]))
+      .to.be.revertedWith("EsGmxIssuer: epoch finalized")
+  })
+
+  it("claims pay the account in full, once", async () => {
+    await esGmx.mint(issuer.address, 1000)
+    await issuer.connect(distributor).distributeEpoch(1, 0, [user0.address], [400])
+
+    await issuer.connect(user0).claim()
+    expect(await esGmx.balanceOf(user0.address)).eq(400)
+    expect(await issuer.claimable(user0.address)).eq(0)
+    expect(await issuer.totalClaimedAmount()).eq(400)
+
+    await issuer.connect(user0).claim()
+    expect(await esGmx.balanceOf(user0.address)).eq(400)
+
+    await issuer.connect(distributor).distributeEpoch(1, 1, [user0.address], [100])
+    await expect(issuer.connect(user1).claimForAccount(user0.address))
+      .to.be.revertedWith("EsGmxIssuer: forbidden")
+    await issuer.setHandler(user1.address, true)
+    await issuer.connect(user1).claimForAccount(user0.address)
+    expect(await esGmx.balanceOf(user0.address)).eq(500)
+    expect(await esGmx.balanceOf(user1.address)).eq(0)
+  })
+
+  it("guardian pause blocks claims", async () => {
+    await esGmx.mint(issuer.address, 1000)
+    await issuer.connect(distributor).distributeEpoch(1, 0, [user0.address], [400])
+
+    await issuer.connect(guardian).setClaimsPaused(true)
+    await expect(issuer.connect(user0).claim())
+      .to.be.revertedWith("EsGmxIssuer: claims paused")
+
+    await issuer.connect(guardian).setClaimsPaused(false)
+    await issuer.connect(user0).claim()
+    expect(await esGmx.balanceOf(user0.address)).eq(400)
+  })
+
+  it("reduceIssuedAmount reaches only unclaimed amounts", async () => {
+    await esGmx.mint(issuer.address, 1000)
+    await issuer.connect(distributor).distributeEpoch(1, 0, [user0.address], [400])
+
+    await issuer.connect(capsAdmin).reduceIssuedAmount(user0.address, 150)
+    expect(await issuer.issuedAmounts(user0.address)).eq(250)
+    expect(await issuer.claimable(user0.address)).eq(250)
+    expect(await issuer.totalIssuedAmount()).eq(250)
+
+    await issuer.connect(user0).claim()
+    await expect(issuer.connect(capsAdmin).reduceIssuedAmount(user0.address, 1))
+      .to.be.revertedWith("EsGmxIssuer: amount exceeds unclaimed")
+  })
+
+  it("withdrawToken reaches only esGMX above the outstanding ledger", async () => {
+    await esGmx.mint(issuer.address, 1000)
+    await issuer.connect(distributor).distributeEpoch(1, 0, [user0.address], [600])
+
+    await expect(issuer.withdrawToken(esGmx.address, wallet.address, 401))
+      .to.be.revertedWith("EsGmxIssuer: amount exceeds excess balance")
+    await issuer.withdrawToken(esGmx.address, wallet.address, 400)
+    expect(await esGmx.balanceOf(wallet.address)).eq(400)
+
+    await issuer.connect(user0).claim()
+    expect(await esGmx.balanceOf(issuer.address)).eq(0)
+    await expect(issuer.withdrawToken(esGmx.address, wallet.address, 1))
+      .to.be.revertedWith("EsGmxIssuer: amount exceeds excess balance")
+  })
+
+  it("claims need handler status once esGMX is in private transfer mode", async () => {
+    await esGmx.mint(issuer.address, 1000)
+    await issuer.connect(distributor).distributeEpoch(1, 0, [user0.address], [400])
+
+    await esGmx.setInPrivateTransferMode(true)
+    await expect(issuer.connect(user0).claim())
+      .to.be.revertedWith("BaseToken: msg.sender not whitelisted")
+
+    await esGmx.setHandler(issuer.address, true)
+    await issuer.connect(user0).claim()
+    expect(await esGmx.balanceOf(user0.address)).eq(400)
+  })
+})

--- a/test/staking/RatioVester.js
+++ b/test/staking/RatioVester.js
@@ -1,0 +1,445 @@
+const { expect, use } = require("chai")
+const { solidity } = require("ethereum-waffle")
+const { deployContract } = require("../shared/fixtures")
+const { expandDecimals, increaseTime, mineBlock } = require("../shared/utilities")
+
+use(solidity)
+
+const { AddressZero } = ethers.constants
+
+const secondsPerYear = 365 * 24 * 60 * 60
+const EPOCH_DURATION = 7 * 24 * 60 * 60
+const EPOCH_OFFSET = 24 * 60 * 60
+const PAIR_PRECISION = expandDecimals(1, 30)
+
+describe("RatioVester", function () {
+  const provider = waffle.provider
+  const [wallet, user0, user1, user2, capsAdmin, guardian, distributor, handler] = provider.getWallets()
+  let esGmx
+  let gmx
+  let pair
+  let issuer
+  let vester
+
+  const alignToEpochStart = async () => {
+    const block = await provider.getBlock("latest")
+    const next = (Math.floor((block.timestamp + EPOCH_OFFSET) / EPOCH_DURATION) + 1) * EPOCH_DURATION - EPOCH_OFFSET
+    await increaseTime(provider, next - block.timestamp + 60)
+    await mineBlock(provider)
+  }
+
+  const issueAndApprove = async (account, esAmount, pairAmount) => {
+    await issuer.connect(distributor).distributeEpoch(1, await nextBatchIndex(), [account.address], [esAmount])
+    await issuer.connect(account).claim()
+    await esGmx.connect(account).approve(vester.address, esAmount)
+    await pair.mint(account.address, pairAmount)
+    await pair.connect(account).approve(vester.address, pairAmount)
+  }
+
+  let batchIndex = 0
+  const nextBatchIndex = async () => {
+    batchIndex += 1
+    return batchIndex
+  }
+
+  beforeEach(async () => {
+    batchIndex = 0
+    esGmx = await deployContract("EsGMX", [])
+    gmx = await deployContract("Token", [])
+    pair = await deployContract("Token", [])
+
+    issuer = await deployContract("EsGmxIssuer", [esGmx.address])
+    vester = await deployContract("RatioVester", [
+      "Vested GMX S1",
+      "vGMX-S1",
+      secondsPerYear,
+      esGmx.address,
+      pair.address,
+      gmx.address,
+      issuer.address,
+      PAIR_PRECISION.mul(5),
+      false
+    ])
+
+    await esGmx.setMinter(wallet.address, true)
+    await esGmx.setMinter(vester.address, true)
+
+    await issuer.setCapsAdmin(capsAdmin.address)
+    await issuer.connect(capsAdmin).setDistributor(distributor.address, true)
+    await issuer.setVester(vester.address)
+    await vester.confirmIssuerBinding()
+
+    await vester.setCapsAdmin(capsAdmin.address)
+    await vester.setGuardian(guardian.address)
+    await vester.setHandler(handler.address, true)
+
+    await esGmx.mint(issuer.address, expandDecimals(1000000, 18))
+    await gmx.mint(vester.address, expandDecimals(1000000, 18))
+
+    await alignToEpochStart()
+  })
+
+  it("requires the confirmed issuer binding for deposits", async () => {
+    const unbound = await deployContract("RatioVester", [
+      "V", "V", secondsPerYear, esGmx.address, pair.address, gmx.address,
+      issuer.address, PAIR_PRECISION.mul(5), false
+    ])
+    await gmx.mint(unbound.address, expandDecimals(1000, 18))
+    await issueAndApprove(user0, expandDecimals(100, 18), expandDecimals(500, 18))
+    await esGmx.connect(user0).approve(unbound.address, expandDecimals(100, 18))
+    await expect(unbound.connect(user0).deposit(expandDecimals(100, 18)))
+      .to.be.revertedWith("RatioVester: issuer binding not confirmed")
+    await expect(unbound.confirmIssuerBinding())
+      .to.be.revertedWith("RatioVester: issuer not bound")
+  })
+
+  it("caps deposits at issuance and locks pair at the fixed ratio", async () => {
+    await issueAndApprove(user0, expandDecimals(1000, 18), expandDecimals(5000, 18))
+
+    await expect(vester.connect(user0).deposit(expandDecimals(1001, 18)))
+      .to.be.revertedWith("RatioVester: cap exceeded")
+
+    await vester.connect(user0).deposit(expandDecimals(1000, 18))
+    expect(await vester.balances(user0.address)).eq(expandDecimals(1000, 18))
+    expect(await vester.pairAmounts(user0.address)).eq(expandDecimals(5000, 18))
+    expect(await pair.balanceOf(vester.address)).eq(expandDecimals(5000, 18))
+    expect(await vester.getVestingCap(user0.address)).eq(expandDecimals(1000, 18))
+
+    await expect(vester.connect(user0).deposit(expandDecimals(1, 18)))
+      .to.be.revertedWith("RatioVester: cap exceeded")
+  })
+
+  it("term: a new grant after a year of history still takes the full duration", async () => {
+    await issueAndApprove(user0, expandDecimals(100000, 18), expandDecimals(500000, 18))
+    await vester.connect(user0).deposit(expandDecimals(100000, 18))
+
+    await increaseTime(provider, 366 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).claim()
+    expect(await gmx.balanceOf(user0.address)).eq(expandDecimals(100000, 18))
+
+    await issueAndApprove(user0, expandDecimals(1000, 18), 0)
+    await vester.connect(user0).deposit(expandDecimals(1000, 18))
+
+    await increaseTime(provider, 5 * 24 * 60 * 60)
+    await mineBlock(provider)
+
+    const claimable = await vester.claimable(user0.address)
+    expect(claimable).gt(expandDecimals(10, 18))
+    expect(claimable).lt(expandDecimals(20, 18))
+    expect(await vester.balances(user0.address)).gt(expandDecimals(980, 18))
+  })
+
+  it("merges deposits within one epoch into a single tranche anchored at the first", async () => {
+    await issueAndApprove(user0, expandDecimals(600, 18), expandDecimals(3000, 18))
+
+    await vester.connect(user0).deposit(expandDecimals(100, 18))
+    await increaseTime(provider, 2 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).deposit(expandDecimals(200, 18))
+    expect(await vester.tranchesLength(user0.address)).eq(1)
+
+    const tranche = await vester.tranches(user0.address, 0)
+    expect(tranche.totalAmount).eq(expandDecimals(300, 18))
+
+    await increaseTime(provider, 7 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).deposit(expandDecimals(300, 18))
+    expect(await vester.tranchesLength(user0.address)).eq(2)
+  })
+
+  it("collateral: no refund mid-session, full return at withdrawal, converted stays claimable", async () => {
+    await issueAndApprove(user0, expandDecimals(1000, 18), expandDecimals(5000, 18))
+    await vester.connect(user0).deposit(expandDecimals(1000, 18))
+
+    await increaseTime(provider, 100 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).settleTranches(user0.address, 100)
+    expect(await vester.pairAmounts(user0.address)).eq(expandDecimals(5000, 18))
+
+    const esBefore = await esGmx.balanceOf(user0.address)
+    await vester.connect(user0).withdraw()
+
+    expect(await pair.balanceOf(user0.address)).eq(expandDecimals(5000, 18))
+    const esReturned = (await esGmx.balanceOf(user0.address)).sub(esBefore)
+    expect(esReturned).gt(expandDecimals(720, 18))
+    expect(esReturned).lt(expandDecimals(727, 18))
+
+    const unpaid = await vester.unpaidClaimAmounts(user0.address)
+    expect(unpaid).gt(expandDecimals(273, 18))
+    expect(unpaid).lt(expandDecimals(280, 18))
+
+    await vester.connect(user0).claim()
+    expect(await gmx.balanceOf(user0.address)).eq(unpaid)
+    expect(await vester.unpaidClaimAmounts(user0.address)).eq(0)
+  })
+
+  it("counter separation: a closed session's unpaid amount never underflows the next", async () => {
+    await issueAndApprove(user0, expandDecimals(300, 18), expandDecimals(1500, 18))
+    await vester.connect(user0).deposit(expandDecimals(100, 18))
+
+    await increaseTime(provider, 366 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).claim()
+    expect(await gmx.balanceOf(user0.address)).eq(expandDecimals(100, 18))
+
+    await vester.connect(user0).withdraw()
+    expect(await pair.balanceOf(user0.address)).eq(expandDecimals(1500, 18))
+
+    await pair.connect(user0).approve(vester.address, expandDecimals(1500, 18))
+    await vester.connect(user0).deposit(expandDecimals(50, 18))
+    await increaseTime(provider, 10 * 24 * 60 * 60)
+    await mineBlock(provider)
+
+    await vester.connect(user0).withdraw()
+    const unpaid = await vester.unpaidClaimAmounts(user0.address)
+    expect(unpaid).gt(0)
+    await vester.connect(user0).claim()
+    expect(await vester.unpaidClaimAmounts(user0.address)).eq(0)
+  })
+
+  it("conversion clamps to remaining headroom and resumes on unwind", async () => {
+    await issueAndApprove(user0, expandDecimals(1000, 18), expandDecimals(5000, 18))
+    await vester.connect(user0).deposit(expandDecimals(1000, 18))
+
+    await vester.connect(guardian).increaseCapDeduction(user0.address, expandDecimals(900, 18))
+    expect(await vester.getVestingCap(user0.address)).eq(expandDecimals(100, 18))
+
+    await increaseTime(provider, 100 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).settleTranches(user0.address, 100)
+
+    expect(await vester.totalConvertedAmounts(user0.address)).eq(expandDecimals(100, 18))
+
+    await vester.decreaseCapDeduction(user0.address, expandDecimals(900, 18))
+    await vester.connect(user0).settleTranches(user0.address, 100)
+    const converted = await vester.totalConvertedAmounts(user0.address)
+    expect(converted).gt(expandDecimals(270, 18))
+    expect(converted).lt(expandDecimals(280, 18))
+  })
+
+  it("conservation: deduct below converted, transfer, unwind, no headroom reappears", async () => {
+    await issueAndApprove(user0, expandDecimals(100, 18), expandDecimals(500, 18))
+    await vester.connect(user0).deposit(expandDecimals(100, 18))
+    await increaseTime(provider, 300 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).claim()
+    await vester.connect(user0).withdraw()
+
+    const used = await vester.totalConvertedAmounts(user0.address)
+    expect(used).gt(expandDecimals(80, 18))
+
+    await vester.connect(guardian).increaseCapDeduction(user0.address, expandDecimals(30, 18))
+    await vester.connect(capsAdmin).setProvisioningComplete()
+    await vester.connect(handler).transferVestingState(user0.address, user1.address)
+
+    expect(await vester.getVestingCap(user0.address)).eq(0)
+    const receiverCap = await vester.transferredCaps(user1.address)
+    const receiverUsed = await vester.totalConvertedAmounts(user1.address)
+    expect(receiverCap).eq(receiverUsed)
+
+    await vester.decreaseCapDeduction(user0.address, expandDecimals(30, 18))
+    const senderCap = await vester.getVestingCap(user0.address)
+    const senderUsed = await vester.totalConvertedAmounts(user0.address)
+    // exact lineage conservation: sender headroom equals the pre-deduction headroom,
+    // receiver headroom stays zero, so nothing regenerates and nothing is lost
+    expect(senderCap.sub(senderUsed)).eq(expandDecimals(100, 18).sub(used))
+    expect(await vester.getVestingCap(user1.address)).eq(receiverUsed)
+  })
+
+  it("issuance after a transfer stays vestable on the old address", async () => {
+    await issueAndApprove(user0, expandDecimals(1000, 18), expandDecimals(5000, 18))
+    await vester.connect(user0).deposit(expandDecimals(1000, 18))
+    await increaseTime(provider, 146 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).claim()
+    await vester.connect(user0).withdraw()
+
+    await vester.connect(capsAdmin).setProvisioningComplete()
+    await vester.connect(handler).transferVestingState(user0.address, user1.address)
+    expect(await vester.totalConvertedAmounts(user0.address)).eq(0)
+
+    await issueAndApprove(user0, expandDecimals(300, 18), expandDecimals(1500, 18))
+    await vester.connect(user0).deposit(expandDecimals(300, 18))
+    expect(await vester.balances(user0.address)).eq(expandDecimals(300, 18))
+  })
+
+  it("an oversized cap deduction cannot brick settlement or withdrawal", async () => {
+    await issueAndApprove(user0, expandDecimals(100, 18), expandDecimals(500, 18))
+    await vester.connect(user0).deposit(expandDecimals(100, 18))
+    await increaseTime(provider, 30 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).claim()
+    await vester.connect(user0).withdraw()
+    await vester.connect(capsAdmin).setProvisioningComplete()
+    await vester.connect(handler).transferVestingState(user0.address, user1.address)
+
+    await issueAndApprove(user0, expandDecimals(50, 18), expandDecimals(250, 18))
+    await vester.connect(user0).deposit(expandDecimals(50, 18))
+
+    await vester.connect(guardian).increaseCapDeduction(user0.address, ethers.constants.MaxUint256)
+    expect(await vester.getVestingCap(user0.address)).eq(0)
+    const esBefore = await esGmx.balanceOf(user0.address)
+    await vester.connect(user0).withdraw()
+    expect((await esGmx.balanceOf(user0.address)).sub(esBefore)).eq(expandDecimals(50, 18))
+  })
+
+  it("operates with esGMX in private transfer mode given the grants-table handlers", async () => {
+    await esGmx.setInPrivateTransferMode(true)
+    await esGmx.setHandler(issuer.address, true)
+    await esGmx.setHandler(vester.address, true)
+
+    await issueAndApprove(user0, expandDecimals(100, 18), expandDecimals(500, 18))
+    await vester.connect(user0).deposit(expandDecimals(100, 18))
+
+    await increaseTime(provider, 100 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await vester.connect(user0).claim()
+    const claimed = await gmx.balanceOf(user0.address)
+    expect(claimed).gt(expandDecimals(27, 18))
+    expect(claimed).lt(expandDecimals(28, 18))
+
+    await vester.connect(user0).withdraw()
+    const esBalance = await esGmx.balanceOf(user0.address)
+    expect(esBalance).gt(expandDecimals(72, 18))
+    expect(esBalance).lt(expandDecimals(73, 18))
+
+    await esGmx.setHandler(vester.address, false)
+    await esGmx.connect(user0).approve(vester.address, expandDecimals(1, 18))
+    await expect(vester.connect(user0).deposit(expandDecimals(1, 18)))
+      .to.be.revertedWith("BaseToken: msg.sender not whitelisted")
+  })
+
+  it("transfer guards: open session, freshness, pause, provisioning", async () => {
+    await issueAndApprove(user0, expandDecimals(100, 18), expandDecimals(500, 18))
+    await vester.connect(user0).deposit(expandDecimals(100, 18))
+
+    await expect(vester.connect(user0).transferVestingState(user0.address, user1.address))
+      .to.be.revertedWith("RatioVester: forbidden")
+    await expect(vester.connect(handler).transferVestingState(user0.address, user1.address))
+      .to.be.revertedWith("RatioVester: provisioning not complete")
+
+    await vester.connect(capsAdmin).setProvisioningComplete()
+    await expect(vester.connect(handler).transferVestingState(user0.address, user1.address))
+      .to.be.revertedWith("RatioVester: sender has open session")
+
+    await vester.connect(user0).withdraw()
+    await vester.connect(user0).claim()
+
+    await vester.connect(guardian).setTransferPaused(true)
+    await expect(vester.connect(handler).transferVestingState(user0.address, user1.address))
+      .to.be.revertedWith("RatioVester: transfers paused")
+    await vester.connect(guardian).setTransferPaused(false)
+
+    await vester.connect(handler).transferVestingState(user0.address, user1.address)
+
+    await expect(vester.connect(handler).transferVestingState(user2.address, user1.address))
+      .to.be.revertedWith("RatioVester: receiver not fresh")
+  })
+
+  it("solvency: a deposit beyond backing reverts at the deposit", async () => {
+    const lean = await deployContract("RatioVester", [
+      "V", "V", secondsPerYear, esGmx.address, pair.address, gmx.address,
+      AddressZero, PAIR_PRECISION.mul(5), false
+    ])
+    await lean.setCapsAdmin(capsAdmin.address)
+    await lean.connect(capsAdmin).setProvisionCaps([user0.address], [expandDecimals(1000, 18)])
+    await gmx.mint(lean.address, expandDecimals(400, 18))
+
+    await esGmx.mint(user0.address, expandDecimals(1000, 18))
+    await esGmx.connect(user0).approve(lean.address, expandDecimals(1000, 18))
+    await pair.mint(user0.address, expandDecimals(5000, 18))
+    await pair.connect(user0).approve(lean.address, expandDecimals(5000, 18))
+
+    await expect(lean.connect(user0).deposit(expandDecimals(500, 18)))
+      .to.be.revertedWith("RatioVester: insufficient backing")
+    await lean.connect(user0).deposit(expandDecimals(400, 18))
+  })
+
+  it("freeze halts conversion and claims, never withdrawal", async () => {
+    await issueAndApprove(user0, expandDecimals(1000, 18), expandDecimals(5000, 18))
+    await vester.connect(user0).deposit(expandDecimals(1000, 18))
+
+    await vester.connect(guardian).setAccountFrozen(user0.address, true)
+    await increaseTime(provider, 100 * 24 * 60 * 60)
+    await mineBlock(provider)
+
+    expect(await vester.claimable(user0.address)).eq(0)
+    await expect(vester.connect(user0).claim())
+      .to.be.revertedWith("RatioVester: account frozen")
+
+    await vester.connect(user0).withdraw()
+    expect(await esGmx.balanceOf(user0.address)).eq(expandDecimals(1000, 18))
+    expect(await pair.balanceOf(user0.address)).eq(expandDecimals(5000, 18))
+  })
+
+  it("deactivation: notice, push-out only, vesting freezes while claims stay open", async () => {
+    await expect(vester.setDeactivatedAt((await provider.getBlock("latest")).timestamp + 1000))
+      .to.be.revertedWith("RatioVester: notice period too short")
+
+    await issueAndApprove(user0, expandDecimals(1000, 18), expandDecimals(5000, 18))
+    await vester.connect(user0).deposit(expandDecimals(1000, 18))
+
+    const now = (await provider.getBlock("latest")).timestamp
+    const deactivateAt = now + 10 * 24 * 60 * 60
+    await vester.setDeactivatedAt(deactivateAt)
+    await expect(vester.setDeactivatedAt(deactivateAt - 1))
+      .to.be.revertedWith("RatioVester: can only push out")
+
+    await increaseTime(provider, 30 * 24 * 60 * 60)
+    await mineBlock(provider)
+
+    await expect(vester.connect(user0).deposit(expandDecimals(1, 18)))
+      .to.be.revertedWith("RatioVester: deactivated")
+    await expect(vester.setDeactivatedAt(deactivateAt + 1000))
+      .to.be.revertedWith("RatioVester: already deactivated")
+
+    const claimable = await vester.claimable(user0.address)
+    expect(claimable).gt(expandDecimals(26, 18))
+    expect(claimable).lt(expandDecimals(29, 18))
+
+    await vester.connect(user0).claim()
+    await vester.connect(user0).withdraw()
+    expect(await pair.balanceOf(user0.address)).eq(expandDecimals(5000, 18))
+  })
+
+  it("paginated settle walks a backlog to completion", async () => {
+    await issueAndApprove(user0, expandDecimals(500, 18), expandDecimals(2500, 18))
+
+    for (let i = 0; i < 5; i++) {
+      await vester.connect(user0).deposit(expandDecimals(100, 18))
+      await increaseTime(provider, 7 * 24 * 60 * 60)
+      await mineBlock(provider)
+    }
+    expect(await vester.tranchesLength(user0.address)).eq(5)
+
+    await increaseTime(provider, 366 * 24 * 60 * 60)
+    await mineBlock(provider)
+
+    await vester.connect(user1).settleTranches(user0.address, 2)
+    expect(await vester.trancheStartIndex(user0.address)).eq(2)
+    await vester.connect(user1).settleTranches(user0.address, 2)
+    expect(await vester.trancheStartIndex(user0.address)).eq(4)
+    await vester.connect(user1).settleTranches(user0.address, 2)
+    expect(await vester.trancheStartIndex(user0.address)).eq(5)
+
+    await vester.connect(user0).claim()
+    expect(await gmx.balanceOf(user0.address)).eq(expandDecimals(500, 18))
+  })
+
+  it("withdrawToken never reaches collateral, in-flight esGMX, or GMX obligations", async () => {
+    await issueAndApprove(user0, expandDecimals(1000, 18), expandDecimals(5000, 18))
+    await vester.connect(user0).deposit(expandDecimals(1000, 18))
+
+    await expect(vester.withdrawToken(pair.address, wallet.address, 1))
+      .to.be.revertedWith("RatioVester: amount exceeds excess balance")
+    await expect(vester.withdrawToken(esGmx.address, wallet.address, 1))
+      .to.be.revertedWith("RatioVester: amount exceeds excess balance")
+
+    const gmxBalance = await gmx.balanceOf(vester.address)
+    const excess = gmxBalance.sub(expandDecimals(1000, 18))
+    await expect(vester.withdrawToken(gmx.address, wallet.address, excess.add(1)))
+      .to.be.revertedWith("RatioVester: amount exceeds excess balance")
+    await vester.withdrawToken(gmx.address, wallet.address, excess)
+  })
+})

--- a/test/staking/RewardRouterV3.js
+++ b/test/staking/RewardRouterV3.js
@@ -1,0 +1,346 @@
+const { expect, use } = require("chai")
+const { solidity } = require("ethereum-waffle")
+const { deployContract } = require("../shared/fixtures")
+const { expandDecimals, increaseTime, mineBlock } = require("../shared/utilities")
+
+use(solidity)
+
+const { AddressZero } = ethers.constants
+const secondsPerYear = 365 * 24 * 60 * 60
+const PAIR_PRECISION = expandDecimals(1, 30)
+
+describe("RewardRouterV3", function () {
+  const provider = waffle.provider
+  const [wallet, user0, user1, user2, user3, capsAdmin, guardian, distributor] = provider.getWallets()
+  let gmx, esGmx, bnGmx, weth, glp
+  let stakedGmxTracker, bonusGmxTracker, extendedGmxTracker, feeGmxTracker
+  let feeGlpTracker, stakedGlpTracker
+  let gmxVester, glpVester
+  let issuer, season, orphan
+  let router
+
+  const deployTrackerPair = async (name, symbol, depositTokens, rewardToken, isBonus) => {
+    const tracker = await deployContract("RewardTracker", [name, symbol])
+    const distributorContract = isBonus
+      ? await deployContract("BonusDistributor", [rewardToken, tracker.address])
+      : await deployContract("RewardDistributor", [rewardToken, tracker.address])
+    await tracker.initialize(depositTokens, distributorContract.address)
+    return tracker
+  }
+
+  const initRouter = async (target) => {
+    await target.initialize({
+      weth: weth.address,
+      gmx: gmx.address,
+      esGmx: esGmx.address,
+      bnGmx: bnGmx.address,
+      glp: glp.address,
+      stakedGmxTracker: stakedGmxTracker.address,
+      bonusGmxTracker: bonusGmxTracker.address,
+      extendedGmxTracker: extendedGmxTracker.address,
+      feeGmxTracker: feeGmxTracker.address,
+      feeGlpTracker: feeGlpTracker.address,
+      stakedGlpTracker: stakedGlpTracker.address,
+      glpManager: AddressZero,
+      gmxVester: gmxVester.address,
+      glpVester: glpVester.address,
+      externalHandler: AddressZero,
+      govToken: AddressZero,
+      esGmxIssuer: issuer.address
+    })
+  }
+
+  const wireHandlers = async (target) => {
+    for (const tracker of [stakedGmxTracker, bonusGmxTracker, extendedGmxTracker, feeGmxTracker, feeGlpTracker, stakedGlpTracker]) {
+      await tracker.setHandler(target.address, true)
+    }
+    await esGmx.setHandler(target.address, true)
+    await bnGmx.setMinter(target.address, true)
+  }
+
+  const stakeGmxFor = async (account, amount) => {
+    await gmx.mint(account.address, amount)
+    await gmx.connect(account).approve(stakedGmxTracker.address, ethers.constants.MaxUint256)
+    await router.connect(account).stakeGmx(amount)
+  }
+
+  let batchIndex = 0
+  const issueTo = async (account, amount) => {
+    batchIndex += 1
+    await issuer.connect(distributor).distributeEpoch(1, batchIndex, [account.address], [amount])
+  }
+
+  beforeEach(async () => {
+    batchIndex = 0
+    gmx = await deployContract("Token", [])
+    esGmx = await deployContract("EsGMX", [])
+    bnGmx = await deployContract("MintableBaseToken", ["Bonus GMX", "bnGMX", 0])
+    weth = await deployContract("Token", [])
+    glp = await deployContract("MintableBaseToken", ["GMX LP", "GLP", 0])
+
+    stakedGmxTracker = await deployTrackerPair("Staked GMX", "sGMX", [gmx.address, esGmx.address], esGmx.address, false)
+    bonusGmxTracker = await deployTrackerPair("Staked + Bonus GMX", "sbGMX", [stakedGmxTracker.address], bnGmx.address, true)
+    extendedGmxTracker = await deployTrackerPair("Staked + Bonus + Extended GMX", "sbeGMX", [bonusGmxTracker.address, bnGmx.address], gmx.address, false)
+    feeGmxTracker = await deployTrackerPair("Staked + Bonus + Fee GMX", "sbfGMX", [extendedGmxTracker.address, bnGmx.address], weth.address, false)
+    feeGlpTracker = await deployTrackerPair("Fee GLP", "fGLP", [glp.address], weth.address, false)
+    stakedGlpTracker = await deployTrackerPair("Fee + Staked GLP", "fsGLP", [feeGlpTracker.address], esGmx.address, false)
+
+    gmxVester = await deployContract("Vester", [
+      "Vested GMX", "veGMX", secondsPerYear, esGmx.address, feeGmxTracker.address, gmx.address, stakedGmxTracker.address
+    ])
+    glpVester = await deployContract("Vester", [
+      "Vested GLP", "veGLP", secondsPerYear, esGmx.address, stakedGlpTracker.address, gmx.address, stakedGlpTracker.address
+    ])
+
+    issuer = await deployContract("EsGmxIssuer", [esGmx.address])
+    season = await deployContract("RatioVester", [
+      "Vested GMX S1", "vGMX-S1", secondsPerYear, esGmx.address, feeGmxTracker.address, gmx.address,
+      issuer.address, PAIR_PRECISION.mul(5), false
+    ])
+    orphan = await deployContract("RatioVester", [
+      "Vested GMX Orphan", "vGMX-O", secondsPerYear, esGmx.address, feeGmxTracker.address, gmx.address,
+      AddressZero, PAIR_PRECISION.mul(10), false
+    ])
+
+    // chain custody: each level holds handler status on the previous level's receipt
+    await stakedGmxTracker.setHandler(bonusGmxTracker.address, true)
+    await bonusGmxTracker.setHandler(extendedGmxTracker.address, true)
+    await extendedGmxTracker.setHandler(feeGmxTracker.address, true)
+    await feeGlpTracker.setHandler(stakedGlpTracker.address, true)
+
+    router = await deployContract("RewardRouterV3", [])
+    await initRouter(router)
+    await router.addDesignatedVester(season.address)
+    await router.addDesignatedVester(orphan.address)
+    await wireHandlers(router)
+
+    await esGmx.setMinter(wallet.address, true)
+    await esGmx.setMinter(gmxVester.address, true)
+    await esGmx.setMinter(season.address, true)
+    await esGmx.setMinter(orphan.address, true)
+
+    await issuer.setCapsAdmin(capsAdmin.address)
+    await issuer.connect(capsAdmin).setDistributor(distributor.address, true)
+    await issuer.setVester(season.address)
+    await issuer.setHandler(router.address, true)
+    await season.confirmIssuerBinding()
+
+    await season.setCapsAdmin(capsAdmin.address)
+    await season.setGuardian(guardian.address)
+    await season.setHandler(router.address, true)
+    await season.connect(capsAdmin).setProvisioningComplete()
+
+    await orphan.setCapsAdmin(capsAdmin.address)
+    await orphan.setHandler(router.address, true)
+    await orphan.connect(capsAdmin).setProvisionCaps([user0.address], [expandDecimals(1000, 18)])
+    await orphan.connect(capsAdmin).setProvisioningComplete()
+
+    // pair custody pulls by the vesters
+    await feeGmxTracker.setHandler(gmxVester.address, true)
+    await feeGmxTracker.setHandler(season.address, true)
+    await feeGmxTracker.setHandler(orphan.address, true)
+
+    // handler for seeding legacy state in tests
+    await gmxVester.setHandler(wallet.address, true)
+
+    await esGmx.mint(issuer.address, expandDecimals(1000000, 18))
+    await gmx.mint(season.address, expandDecimals(1000000, 18))
+    await gmx.mint(orphan.address, expandDecimals(1000000, 18))
+  })
+
+  it("stakes through the full four-tracker chain", async () => {
+    await stakeGmxFor(user0, expandDecimals(100, 18))
+    expect(await stakedGmxTracker.stakedAmounts(user0.address)).eq(expandDecimals(100, 18))
+    expect(await feeGmxTracker.stakedAmounts(user0.address)).eq(expandDecimals(100, 18))
+    expect(await feeGmxTracker.balanceOf(user0.address)).eq(expandDecimals(100, 18))
+  })
+
+  it("proxy binds the caller and rejects non-designated vesters", async () => {
+    await issueTo(user0, expandDecimals(1000, 18))
+    await router.connect(user0).issuerClaim()
+    expect(await esGmx.balanceOf(user0.address)).eq(expandDecimals(1000, 18))
+
+    await stakeGmxFor(user0, expandDecimals(5000, 18))
+    await esGmx.connect(user0).approve(season.address, expandDecimals(1000, 18))
+
+    await expect(router.connect(user0).vesterDeposit(gmxVester.address, expandDecimals(1000, 18)))
+      .to.be.revertedWith("invalid vester")
+
+    await router.connect(user0).vesterDeposit(season.address, expandDecimals(1000, 18))
+    expect(await season.balances(user0.address)).eq(expandDecimals(1000, 18))
+    expect(await season.pairAmounts(user0.address)).eq(expandDecimals(5000, 18))
+    expect(await feeGmxTracker.balanceOf(season.address)).eq(expandDecimals(5000, 18))
+    expect(await feeGmxTracker.stakedAmounts(season.address)).eq(0)
+
+    await increaseTime(provider, 100 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await router.connect(user0).vesterClaim(season.address)
+    expect(await gmx.balanceOf(user0.address)).gt(expandDecimals(273, 18))
+
+    await router.connect(user0).vesterWithdraw(season.address)
+    expect(await feeGmxTracker.balanceOf(user0.address)).eq(expandDecimals(5000, 18))
+  })
+
+  it("deleted-calls regression: a zeroed sender with bonusRewards transfers on V3 and reverts on V2", async () => {
+    const routerV2 = await deployContract("RewardRouterV2", [])
+    await routerV2.initialize({
+      weth: weth.address,
+      gmx: gmx.address,
+      esGmx: esGmx.address,
+      bnGmx: bnGmx.address,
+      glp: glp.address,
+      stakedGmxTracker: stakedGmxTracker.address,
+      bonusGmxTracker: bonusGmxTracker.address,
+      extendedGmxTracker: extendedGmxTracker.address,
+      feeGmxTracker: feeGmxTracker.address,
+      feeGlpTracker: feeGlpTracker.address,
+      stakedGlpTracker: stakedGlpTracker.address,
+      glpManager: AddressZero,
+      gmxVester: gmxVester.address,
+      glpVester: glpVester.address,
+      externalHandler: AddressZero,
+      govToken: AddressZero
+    })
+    await wireHandlers(routerV2)
+    await gmxVester.setHandler(routerV2.address, true)
+    await glpVester.setHandler(routerV2.address, true)
+
+    // simulate the post-zeroing state: bonusRewards > 0 and deduction above tracker cumulativeRewards
+    for (const account of [user0, user2]) {
+      await gmxVester.setBonusRewards(account.address, expandDecimals(1000, 18))
+      await gmxVester.setCumulativeRewardDeductions(account.address, expandDecimals(1000, 18))
+    }
+    await stakeGmxFor(user0, expandDecimals(100, 18))
+    await gmx.mint(user2.address, expandDecimals(100, 18))
+    await gmx.connect(user2).approve(stakedGmxTracker.address, ethers.constants.MaxUint256)
+    await routerV2.connect(user2).stakeGmx(expandDecimals(100, 18))
+
+    await routerV2.connect(user2).signalTransfer(user3.address)
+    await expect(routerV2.connect(user3).acceptTransfer(user2.address))
+      .to.be.revertedWith("SafeMath: subtraction overflow")
+
+    await router.connect(user0).signalTransfer(user1.address)
+    await router.connect(user1).acceptTransfer(user0.address)
+    expect(await feeGmxTracker.stakedAmounts(user1.address)).eq(expandDecimals(100, 18))
+    expect(await feeGmxTracker.stakedAmounts(user0.address)).eq(0)
+  })
+
+  it("claims pending issuance to the sender before the sweep and moves the cap", async () => {
+    await issueTo(user0, expandDecimals(500, 18))
+    await stakeGmxFor(user0, expandDecimals(10, 18))
+
+    await router.connect(user0).signalTransfer(user1.address)
+    await router.connect(user1).acceptTransfer(user0.address)
+
+    expect(await esGmx.balanceOf(user1.address)).eq(expandDecimals(500, 18))
+    expect(await esGmx.balanceOf(user0.address)).eq(0)
+    expect(await issuer.claimable(user0.address)).eq(0)
+    expect(await season.transferredCaps(user1.address)).eq(expandDecimals(500, 18))
+    expect(await season.getVestingCap(user0.address)).eq(0)
+    expect(await season.isFreshForTransfer(user1.address)).eq(false)
+  })
+
+  it("an unpayable pending claim blocks the transfer", async () => {
+    await issueTo(user0, expandDecimals(500, 18))
+    await stakeGmxFor(user0, expandDecimals(10, 18))
+    await issuer.setGuardian(guardian.address)
+    await issuer.connect(guardian).setClaimsPaused(true)
+
+    await router.connect(user0).signalTransfer(user1.address)
+    await expect(router.connect(user1).acceptTransfer(user0.address))
+      .to.be.revertedWith("EsGmxIssuer: claims paused")
+  })
+
+  it("a sender mid-session in either new vester is blocked", async () => {
+    await issueTo(user0, expandDecimals(100, 18))
+    await router.connect(user0).issuerClaim()
+    await stakeGmxFor(user0, expandDecimals(1000, 18))
+    await esGmx.connect(user0).approve(season.address, expandDecimals(100, 18))
+    await router.connect(user0).vesterDeposit(season.address, expandDecimals(100, 18))
+
+    await expect(router.connect(user0).signalTransfer(user1.address))
+      .to.be.revertedWith("sender has open session")
+
+    await router.connect(user0).vesterWithdraw(season.address)
+
+    const esBalance = await esGmx.balanceOf(user0.address)
+    await esGmx.connect(user0).approve(orphan.address, esBalance)
+    await router.connect(user0).vesterDeposit(orphan.address, esBalance)
+    await expect(router.connect(user0).signalTransfer(user1.address))
+      .to.be.revertedWith("sender has open session")
+  })
+
+  it("adds the legacy pairAmounts check the balance-only check misses", async () => {
+    await stakeGmxFor(user0, expandDecimals(1000, 18))
+    await gmxVester.setTransferredAverageStakedAmounts(user0.address, expandDecimals(1000, 18))
+    await gmxVester.setTransferredCumulativeRewards(user0.address, expandDecimals(100, 18))
+
+    await esGmx.mint(user0.address, expandDecimals(100, 18))
+    await esGmx.connect(user0).approve(gmxVester.address, expandDecimals(100, 18))
+    await gmxVester.connect(user0).deposit(expandDecimals(100, 18))
+    expect(await gmxVester.pairAmounts(user0.address)).eq(expandDecimals(1000, 18))
+
+    await increaseTime(provider, 366 * 24 * 60 * 60)
+    await mineBlock(provider)
+    await gmx.mint(gmxVester.address, expandDecimals(100, 18))
+    await gmxVester.connect(user0).claim()
+    expect(await gmxVester.balanceOf(user0.address)).eq(0)
+
+    await expect(router.connect(user0).signalTransfer(user1.address))
+      .to.be.revertedWith("sender has pair amounts")
+  })
+
+  it("an empty designated-vester allowlist blocks transfers", async () => {
+    const bare = await deployContract("RewardRouterV3", [])
+    await initRouter(bare)
+    await expect(bare.connect(user0).signalTransfer(user1.address))
+      .to.be.revertedWith("no designated vesters")
+    await expect(bare.connect(user1).acceptTransfer(user0.address))
+      .to.be.revertedWith("no designated vesters")
+  })
+
+  it("compound succeeds with pair collateral locked in a new vester", async () => {
+    await issueTo(user0, expandDecimals(1000, 18))
+    await router.connect(user0).issuerClaim()
+    await stakeGmxFor(user0, expandDecimals(6000, 18))
+    await esGmx.connect(user0).approve(season.address, expandDecimals(1000, 18))
+    await router.connect(user0).vesterDeposit(season.address, expandDecimals(1000, 18))
+
+    await router.connect(user0).compound()
+    expect(await feeGmxTracker.stakedAmounts(user0.address)).eq(expandDecimals(6000, 18))
+  })
+
+  it("an issuer claims pause does not block transfers for senders with nothing pending", async () => {
+    await stakeGmxFor(user0, expandDecimals(10, 18))
+    await issuer.setGuardian(guardian.address)
+    await issuer.connect(guardian).setClaimsPaused(true)
+
+    await router.connect(user0).signalTransfer(user1.address)
+    await router.connect(user1).acceptTransfer(user0.address)
+    expect(await feeGmxTracker.stakedAmounts(user1.address)).eq(expandDecimals(10, 18))
+  })
+
+  it("handleRewards skips vesters without a handler grant or with a frozen account", async () => {
+    await stakeGmxFor(user0, expandDecimals(10, 18))
+
+    await season.setHandler(router.address, false)
+    await orphan.setHandler(router.address, false)
+    await router.connect(user0).handleRewards(true, false, false, false, false, false, false)
+
+    await season.setHandler(router.address, true)
+    await orphan.setHandler(router.address, true)
+    await season.connect(guardian).setAccountFrozen(user0.address, true)
+    await router.connect(user0).handleRewards(true, false, false, false, false, false, false)
+  })
+
+  it("acceptTransfer claims each designated vester's own issuer, not the router slot", async () => {
+    await router.setEsGmxIssuer(AddressZero)
+    await issueTo(user0, expandDecimals(200, 18))
+    await stakeGmxFor(user0, expandDecimals(10, 18))
+
+    await router.connect(user0).signalTransfer(user1.address)
+    await router.connect(user1).acceptTransfer(user0.address)
+    expect(await esGmx.balanceOf(user1.address)).eq(expandDecimals(200, 18))
+    expect(await issuer.claimable(user0.address)).eq(0)
+  })
+})

--- a/test/staking/VesterCapZeroer.js
+++ b/test/staking/VesterCapZeroer.js
@@ -1,0 +1,140 @@
+const { expect, use } = require("chai")
+const { solidity } = require("ethereum-waffle")
+const { deployContract } = require("../shared/fixtures")
+const { expandDecimals, increaseTime, mineBlock } = require("../shared/utilities")
+
+use(solidity)
+
+const { AddressZero } = ethers.constants
+const secondsPerYear = 365 * 24 * 60 * 60
+
+describe("VesterCapZeroer", function () {
+  const provider = waffle.provider
+  const [wallet, user0, user1, user2, capsAdmin, keeper] = provider.getWallets()
+  let esGmx
+  let gmx
+  let tracker
+  let distributor
+  let vester
+  let zeroer
+
+  beforeEach(async () => {
+    esGmx = await deployContract("EsGMX", [])
+    gmx = await deployContract("Token", [])
+
+    tracker = await deployContract("RewardTracker", ["Staked GMX", "sGMX"])
+    distributor = await deployContract("RewardDistributor", [esGmx.address, tracker.address])
+    await tracker.initialize([gmx.address, esGmx.address], distributor.address)
+
+    vester = await deployContract("Vester", [
+      "Vested GMX",
+      "veGMX",
+      secondsPerYear,
+      esGmx.address,
+      AddressZero,
+      gmx.address,
+      tracker.address
+    ])
+
+    zeroer = await deployContract("VesterCapZeroer", [vester.address])
+    await zeroer.setCapsAdmin(capsAdmin.address)
+    await zeroer.connect(capsAdmin).setKeeper(keeper.address, true)
+
+    // wallet acts as an operational handler to seed legacy cap terms
+    await vester.setHandler(wallet.address, true)
+    await esGmx.setMinter(wallet.address, true)
+    await esGmx.setMinter(vester.address, true)
+  })
+
+  it("derives the tracker from the vester", async () => {
+    expect(await zeroer.vester()).eq(vester.address)
+    expect(await zeroer.rewardTracker()).eq(tracker.address)
+  })
+
+  it("gates keeper and keeper grants", async () => {
+    await expect(zeroer.connect(user0).zeroCaps([user0.address]))
+      .to.be.revertedWith("VesterCapZeroer: forbidden")
+    await expect(zeroer.connect(user0).setKeeper(user0.address, true))
+      .to.be.revertedWith("Guardable: forbidden")
+  })
+
+  it("cannot run without handler status on the vester", async () => {
+    await vester.setBonusRewards(user0.address, expandDecimals(1000, 18))
+    await expect(zeroer.connect(keeper).zeroCaps([user0.address]))
+      .to.be.revertedWith("Vester: forbidden")
+  })
+
+  it("raises deductions to the positive terms and skips converged accounts", async () => {
+    await vester.setHandler(zeroer.address, true)
+
+    await vester.setBonusRewards(user0.address, expandDecimals(1000, 18))
+    await vester.setTransferredCumulativeRewards(user1.address, expandDecimals(500, 18))
+
+    expect(await zeroer.getPositiveTerms(user0.address)).eq(expandDecimals(1000, 18))
+    expect(await zeroer.isZeroed(user0.address)).eq(false)
+    expect(await zeroer.isZeroed(user2.address)).eq(true)
+
+    await zeroer.connect(keeper).zeroCaps([user0.address, user1.address, user2.address])
+
+    expect(await vester.cumulativeRewardDeductions(user0.address)).eq(expandDecimals(1000, 18))
+    expect(await vester.cumulativeRewardDeductions(user1.address)).eq(expandDecimals(500, 18))
+    expect(await vester.cumulativeRewardDeductions(user2.address)).eq(0)
+    expect(await vester.getMaxVestableAmount(user0.address)).eq(0)
+    expect(await vester.getMaxVestableAmount(user1.address)).eq(0)
+    expect(await zeroer.isZeroed(user0.address)).eq(true)
+  })
+
+  it("is repeatable until convergence and re-zeroes reopened caps", async () => {
+    await vester.setHandler(zeroer.address, true)
+    await vester.setBonusRewards(user0.address, expandDecimals(1000, 18))
+
+    await zeroer.connect(keeper).zeroCaps([user0.address])
+    await zeroer.connect(keeper).zeroCaps([user0.address])
+    expect(await vester.cumulativeRewardDeductions(user0.address)).eq(expandDecimals(1000, 18))
+
+    await vester.setBonusRewards(user0.address, expandDecimals(1200, 18))
+    expect(await vester.getMaxVestableAmount(user0.address)).eq(expandDecimals(200, 18))
+
+    await zeroer.connect(keeper).zeroCaps([user0.address])
+    expect(await vester.cumulativeRewardDeductions(user0.address)).eq(expandDecimals(1200, 18))
+    expect(await vester.getMaxVestableAmount(user0.address)).eq(0)
+  })
+
+  it("never lowers an existing deduction", async () => {
+    await vester.setHandler(zeroer.address, true)
+    await vester.setTransferredCumulativeRewards(user1.address, expandDecimals(500, 18))
+    await vester.setCumulativeRewardDeductions(user1.address, expandDecimals(5000, 18))
+
+    await zeroer.connect(keeper).zeroCaps([user1.address])
+    expect(await vester.cumulativeRewardDeductions(user1.address)).eq(expandDecimals(5000, 18))
+  })
+
+  it("blocks new deposits only; existing positions keep vesting, claiming, withdrawing", async () => {
+    await vester.setHandler(zeroer.address, true)
+    await vester.setBonusRewards(user0.address, expandDecimals(1000, 18))
+
+    await esGmx.mint(user0.address, expandDecimals(400, 18))
+    await esGmx.connect(user0).approve(vester.address, expandDecimals(400, 18))
+    await vester.connect(user0).deposit(expandDecimals(400, 18))
+
+    await zeroer.connect(keeper).zeroCaps([user0.address])
+
+    await esGmx.mint(user0.address, expandDecimals(10, 18))
+    await esGmx.connect(user0).approve(vester.address, expandDecimals(10, 18))
+    await expect(vester.connect(user0).deposit(expandDecimals(10, 18)))
+      .to.be.revertedWith("Vester: max vestable amount exceeded")
+
+    await increaseTime(provider, 100 * 24 * 60 * 60)
+    await mineBlock(provider)
+
+    await gmx.mint(vester.address, expandDecimals(400, 18))
+    await vester.connect(user0).claim()
+    const claimed = await gmx.balanceOf(user0.address)
+    expect(claimed).gt(expandDecimals(109, 18))
+    expect(claimed).lt(expandDecimals(110, 18))
+
+    await vester.connect(user0).withdraw()
+    const esBalance = await esGmx.balanceOf(user0.address)
+    expect(esBalance).gt(expandDecimals(299, 18))
+  })
+})


### PR DESCRIPTION
- Adds an escrow issuance ledger (EsGmxIssuer) that distributes weekly esGMX in per-epoch batches with replay protection, a funding-bound invariant, and pausable claims
- Adds a vesting contract (RatioVester) with epoch-merged tranches vesting linearly over the configured duration, issuance-backed caps with deduction support, fixed-ratio pair collateral, and full account state transfer
- Adds RewardRouterV3, which routes staking, rewards, and account transfers through a designated-vester list in place of the hard-coded legacy vester flow, drops GLP mint/redeem (served by the GLP-only router since the buyback deployment), and merges the duplicated handleRewards bodies to stay under the contract size limit
- Adds a keeper batch tool (VesterCapZeroer) that closes legacy vester caps via cumulative reward deductions during migration
Introduces capsAdmin and guardian roles for the new contracts via a shared Guardable base
- Adds a reader contract for frontend queries and 49 tests across five suites, including a differential account-transfer regression against RewardRouterV2